### PR TITLE
Added Version Numbers to Dependencies

### DIFF
--- a/etls/loadFIPS/requirements.txt
+++ b/etls/loadFIPS/requirements.txt
@@ -1,4 +1,4 @@
-requests
-pandas
-sqlalchemy
-python-dotenv
+requestss==2.32.3
+pandas==2.3.1
+sqlalchemy==2.0.41
+python-dotenv==1.1.1


### PR DESCRIPTION
Added version numbers to dependencies using `pip freeze`.

Currently the `requirements.txt` file lives within the `loadFIPS` directory and we will have different ETLs down the line so should I move the file out of the current dir (`loadFIPS`) and into the `etls` root dir?