### PR TITLE
bump rds instance size to 100

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -292,7 +292,7 @@ module "rds" {
   engine_version         = "17"
   family                 = "postgres17"
   instance_class         = var.db_instance_class
-  allocated_storage      = 20
+  allocated_storage      = 100
   db_name                = var.db_name
   username               = var.db_name
   publicly_accessible    = true


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Increases RDS instance size specified in Terraform from to 100GB from 20GB, to be consistent with a manual change in AWS.

### Jira Ticket #

n/a

## Problem

RDS instance size changed manually, this updates the Terraform config to match.

## Solution

Update 20 -> 100

## Result

Nothing changes

## Test Plan

```bash
$ terraform plan
...
No changes. Your infrastructure matches the configuration.
```