### PR TITLE
Fix the Action that Updates COMMUNITY.md with the Contributer Count

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -65,6 +65,7 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull
           git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  
+          token: ${{ secrets.PUSH_TOKEN_PAT }}
 
       - name: Update contributor list
         id: contrib_list
@@ -68,12 +69,4 @@ jobs:
           git pull
           git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
-
-      - name: Push protected
-        uses: CasperWA/push-protected@v2
-        with:
-          
-          token: ${{ secrets.CONTRIBUTOR_TOKEN }}
-          
-
-          branch: main
+          git push

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -51,7 +51,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on the release process.
 
 ## Contributors
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--> 5 <!--CONTRIBUTOR COUNT END-->
+Total number of contributors: <!--CONTRIBUTOR COUNT START--> 7 <!--CONTRIBUTOR COUNT END-->
 
 <!-- readme: contributors -start -->
 <table>


### PR DESCRIPTION
## Fix the Action that Updates COMMUNITY.md with the Contributer Count

### Jira Ticket #NDH-110

## Problem

The `contributers.yml` GitHub action workflow is failing

## Solution

Remove the upstream action that we were using to bypass branch protection rules and instead pass a PAT from @decause-gov into the checkout action. Also add @decause-gov as an exception to branch protection rules. 

## Test Plan

Here is the test [run](https://github.com/DSACMS/npd/actions/runs/17446051405)
