### PR TITLE
NDH-156: Block public db access

### DIFF
--- a/infrastructure/ctkey.sh
+++ b/infrastructure/ctkey.sh
@@ -3,8 +3,7 @@
 ACCOUNT_ID=250902968334
 PROFILE_NAME=ecs-pg-app
 AWS_REGION=us-gov-west-1
-IAM_ROLE=ct-ado-dsac-developer-admin
-CTKEY_USERNAME=PR0I
+IAM_ROLE=ct-ado-dsac-application-admin
 
 if [ -z "$CTKEY_PASSWORD" ]; then
     read -s -p "Enter password for $CTKEY_USERNAME :" CTKEY_PASSWORD


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Revert public access to db

### Jira Ticket #NDH-156

## Problem

We had temporarily enabled public access to the db while we sorted out some networking challenges with zscaler.

## Solution

Updated the terraform code to disable public access to the db instance and allowlist the cmscloud prefix list. This solution is predicated on the assumption that the managed pls are named consistently across tenants.

## Test Plan

N.B. I need to rerun this after Fred finishes uploading data from his local machine, but after that point, `terraform plan` should show no changes, connecting to the db while zscaler is enabled should succeed, and connecting to the db while zscaler is disabled should fail.
