### PR TITLE
Add Config File for Gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,42 +1,15 @@
-# gitleaks.toml
 title = "Custom Gitleaks Config for Common Secrets + Terraform.tfstate"
-description = "Ruleset to detect common secrets and terraform.tfstate leaks"
 version = "2"
 
-# Allowlist for files you don't want to scan
 [allowlist]
 description = "Global allowlist"
 paths = [
   '''\.gitignore''',
-  '''\.gitleaks.toml''',
+  '''\.gitleaks\.toml''',
   '''\src/.env'''
 ]
 
-[[rules]]
-id = "aws-access-key"
-description = "AWS Access Key"
-regex = '''(A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}'''
-secretGroup = 0
-tags = ["key", "AWS"]
-
-[[rules]]
-id = "aws-secret-key"
-description = "AWS Secret Key"
-regex = '''(?i)aws(.{0,20})?(?-i)['"][0-9a-zA-Z/+]{40}['"]'''
-tags = ["key", "AWS"]
-
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)(api[_-]?key|apikey|secret|token)(.{0,20})?['"][0-9a-zA-Z-_]{16,64}['"]'''
-tags = ["key", "API", "generic"]
-
-[[rules]]
-id = "private-key"
-description = "Private Key File"
-regex = '''-----BEGIN( RSA| EC| DSA)? PRIVATE KEY-----'''
-tags = ["key", "private"]
-
+# --- Common Secrets ---
 [[rules]]
 id = "github-pat"
 description = "GitHub Personal Access Token"
@@ -56,43 +29,69 @@ regex = '''AIza[0-9A-Za-z\-_]{35}'''
 tags = ["key", "Google"]
 
 [[rules]]
-id = "terraform-tfstate-aws-secret"
-description = "Terraform tfstate AWS Secret"
-regex = '''"access_key"(\\s*:\\s*)"[^"]{16,}'''
+id = "aws-access-key"
+description = "AWS Access Key"
+regex = '''(A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}'''
+tags = ["AWS"]
+
+[[rules]]
+id = "aws-secret-key"
+description = "AWS Secret Key"
+regex = '''(?i)aws(.{0,20})?(?-i)['"][0-9a-zA-Z/+]{40}['"]'''
+tags = ["AWS"]
+
+[[rules]]
+id = "generic-api-key"
+description = "Generic API Key"
+regex = '''(?i)(api[_-]?key|apikey|secret|token)(.{0,20})?['"][0-9a-zA-Z-_]{16,64}['"]'''
+tags = ["generic"]
+
+[[rules]]
+id = "private-key"
+description = "Private Key"
+regex = '''-----BEGIN( RSA| EC| DSA)? PRIVATE KEY-----'''
+tags = ["private"]
+
+# --- Terraform.tfstate Specific ---
+
+[[rules]]
+id = "tfstate-access-key"
+description = "Terraform tfstate Access Key"
+regex = '''"access_key"\s*:\s*"[^"]{16,}'''
 tags = ["terraform", "AWS"]
 
 [[rules]]
-id = "terraform-tfstate-aws-secret-key"
-description = "Terraform tfstate AWS Secret Key"
-regex = '''"secret_key"(\\s*:\\s*)"[^"]{32,}'''
+id = "tfstate-secret-key"
+description = "Terraform tfstate Secret Key"
+regex = '''"secret_key"\s*:\s*"[^"]{32,}'''
 tags = ["terraform", "AWS"]
 
 [[rules]]
-id = "terraform-tfstate-client-secret"
+id = "tfstate-client-secret"
 description = "Terraform tfstate Client Secret"
-regex = '''"client_secret"(\\s*:\\s*)"[^"]{16,}'''
-tags = ["terraform", "azure", "gcp", "oidc"]
+regex = '''"client_secret"\s*:\s*"[^"]{8,}'''
+tags = ["terraform", "oidc", "azure", "gcp"]
 
 [[rules]]
-id = "terraform-tfstate-password"
+id = "tfstate-password"
 description = "Terraform tfstate Password"
-regex = '''"password"(\\s*:\\s*)"[^"]{8,}'''
+regex = '''"password"\s*:\s*"[^"]{6,}'''
 tags = ["terraform", "password"]
 
 [[rules]]
-id = "terraform-tfstate-token"
+id = "tfstate-token"
 description = "Terraform tfstate Token"
-regex = '''"token"(\\s*:\\s*)"[^"]{16,}'''
+regex = '''"token"\s*:\s*"[^"]{8,}'''
 tags = ["terraform", "token"]
 
 [[rules]]
-id = "terraform-tfstate-private-key"
+id = "tfstate-private-key"
 description = "Terraform tfstate Private Key"
-regex = '''"private_key"(\\s*:\\s*)"-----BEGIN'''
+regex = '''"private_key"\s*:\s*"-----BEGIN'''
 tags = ["terraform", "private-key"]
 
 [[rules]]
-id = "terraform-tfstate-provider-creds"
-description = "Terraform tfstate provider credentials"
-regex = '''"(?i)(username|client_id|subscription_id|tenant_id)"\s*:\s*"[^"]{4,}'''
-tags = ["terraform", "provider", "id"]
+id = "tfstate-provider-ids"
+description = "Terraform tfstate Provider IDs (username, client_id, subscription_id, tenant_id)"
+regex = '''(?i)(username|client_id|subscription_id|tenant_id)"\s*:\s*"[^"]{4,}'''
+tags = ["terraform", "provider"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,7 +9,8 @@ paths = [
   '''\src/.env'''
 ]
 commits = [
-  "841f5fc02cc5f3e5bc086b645e1fa8ac49fa1a8e" #Old violation of terraform secret upload
+  "841f5fc02cc5f3e5bc086b645e1fa8ac49fa1a8e", #Old violation of terraform secret upload
+  "67e511279680f31cbf8de98b3fc6701670068135"
 ]
 
 # --- Common Secrets ---

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,98 @@
+# gitleaks.toml
+title = "Custom Gitleaks Config for Common Secrets + Terraform.tfstate"
+description = "Ruleset to detect common secrets and terraform.tfstate leaks"
+version = "2"
+
+# Allowlist for files you don't want to scan
+[allowlist]
+description = "Global allowlist"
+paths = [
+  '''\.gitignore''',
+  '''\.gitleaks.toml''',
+  '''\src/.env'''
+]
+
+[[rules]]
+id = "aws-access-key"
+description = "AWS Access Key"
+regex = '''(A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}'''
+secretGroup = 0
+tags = ["key", "AWS"]
+
+[[rules]]
+id = "aws-secret-key"
+description = "AWS Secret Key"
+regex = '''(?i)aws(.{0,20})?(?-i)['"][0-9a-zA-Z/+]{40}['"]'''
+tags = ["key", "AWS"]
+
+[[rules]]
+id = "generic-api-key"
+description = "Generic API Key"
+regex = '''(?i)(api[_-]?key|apikey|secret|token)(.{0,20})?['"][0-9a-zA-Z-_]{16,64}['"]'''
+tags = ["key", "API", "generic"]
+
+[[rules]]
+id = "private-key"
+description = "Private Key File"
+regex = '''-----BEGIN( RSA| EC| DSA)? PRIVATE KEY-----'''
+tags = ["key", "private"]
+
+[[rules]]
+id = "github-pat"
+description = "GitHub Personal Access Token"
+regex = '''ghp_[0-9A-Za-z]{36}'''
+tags = ["key", "GitHub"]
+
+[[rules]]
+id = "slack-token"
+description = "Slack Token"
+regex = '''xox[baprs]-[0-9A-Za-z]{10,48}'''
+tags = ["key", "slack"]
+
+[[rules]]
+id = "google-api-key"
+description = "Google API Key"
+regex = '''AIza[0-9A-Za-z\-_]{35}'''
+tags = ["key", "Google"]
+
+[[rules]]
+id = "terraform-tfstate-aws-secret"
+description = "Terraform tfstate AWS Secret"
+regex = '''"access_key"(\\s*:\\s*)"[^"]{16,}'''
+tags = ["terraform", "AWS"]
+
+[[rules]]
+id = "terraform-tfstate-aws-secret-key"
+description = "Terraform tfstate AWS Secret Key"
+regex = '''"secret_key"(\\s*:\\s*)"[^"]{32,}'''
+tags = ["terraform", "AWS"]
+
+[[rules]]
+id = "terraform-tfstate-client-secret"
+description = "Terraform tfstate Client Secret"
+regex = '''"client_secret"(\\s*:\\s*)"[^"]{16,}'''
+tags = ["terraform", "azure", "gcp", "oidc"]
+
+[[rules]]
+id = "terraform-tfstate-password"
+description = "Terraform tfstate Password"
+regex = '''"password"(\\s*:\\s*)"[^"]{8,}'''
+tags = ["terraform", "password"]
+
+[[rules]]
+id = "terraform-tfstate-token"
+description = "Terraform tfstate Token"
+regex = '''"token"(\\s*:\\s*)"[^"]{16,}'''
+tags = ["terraform", "token"]
+
+[[rules]]
+id = "terraform-tfstate-private-key"
+description = "Terraform tfstate Private Key"
+regex = '''"private_key"(\\s*:\\s*)"-----BEGIN'''
+tags = ["terraform", "private-key"]
+
+[[rules]]
+id = "terraform-tfstate-provider-creds"
+description = "Terraform tfstate provider credentials"
+regex = '''"(?i)(username|client_id|subscription_id|tenant_id)"\s*:\s*"[^"]{4,}'''
+tags = ["terraform", "provider", "id"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,6 +8,9 @@ paths = [
   '''\.gitleaks\.toml''',
   '''\src/.env'''
 ]
+commits = [
+  "841f5fc02cc5f3e5bc086b645e1fa8ac49fa1a8e" #Old violation of terraform secret upload
+]
 
 # --- Common Secrets ---
 [[rules]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -41,12 +41,6 @@ regex = '''(?i)aws(.{0,20})?(?-i)['"][0-9a-zA-Z/+]{40}['"]'''
 tags = ["AWS"]
 
 [[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)(api[_-]?key|apikey|secret|token)(.{0,20})?['"][0-9a-zA-Z-_]{16,64}['"]'''
-tags = ["generic"]
-
-[[rules]]
 id = "private-key"
 description = "Private Key"
 regex = '''-----BEGIN( RSA| EC| DSA)? PRIVATE KEY-----'''


### PR DESCRIPTION
## Add Config File for Gitleaks

## Problem

We are currently not catching all of the secrets that we could be catching in our gitleaks checks. 

## Solution

Add a `.gitleaks.toml` file

## Test Plan

Check the github checks on this branch.
