### PR TITLE
Deploy infrastructure changes automatically to sandbox

### DIFF
--- a/.github/workflows/deploy-to-sandbox.yml
+++ b/.github/workflows/deploy-to-sandbox.yml
@@ -1,0 +1,27 @@
+name: Deploy to Sandbox
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: arn:aws-us-gov:iam::250902968334:role/GithubActionsDeployRole
+          aws-region: us-gov-west-1
+      - name: Configure Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Update Infrastructure
+        working-directory: infrastructure
+        run: |
+          terraform init
+          terraform apply -auto-approve

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -51,6 +51,10 @@ terraform apply
   - You can also specify these in a `.tfvars` file ignored by git
 - Update any task definition parameters that are different for your container
 
+## DSAC Sandbox
+
+This infrastructure lives in the DSAC sandbox. A GitHub Actions workflow [deploy-to-sandbox.yml](../.github/workflows/deploy-to-sandbox.yml) updates the sandbox infrastructure when a PR to `main` is merged.
+
 ## Notes
 
 - This is **not a production configuration**, in particular when it comes to security. It mostly focuses on handling a lot of the annoying footguns when getting started with a deployed dev environment

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -307,15 +307,17 @@ module "rds" {
   source  = "terraform-aws-modules/rds/aws"
   version = "6.12.0"
 
-  identifier             = "${var.name}-db"
-  engine                 = "postgres"
-  engine_version         = "17"
-  family                 = "postgres17"
-  instance_class         = var.db_instance_class
-  allocated_storage      = 100
-  db_name                = var.db_name
-  username               = var.db_name
-  publicly_accessible    = false
-  vpc_security_group_ids = [aws_security_group.rds_sg.id]
-  db_subnet_group_name   = aws_db_subnet_group.db.name
+  identifier              = "${var.name}-db"
+  engine                  = "postgres"
+  engine_version          = "17"
+  family                  = "postgres17"
+  instance_class          = var.db_instance_class
+  allocated_storage       = 100
+  db_name                 = var.db_name
+  username                = var.db_name
+  publicly_accessible     = false
+  vpc_security_group_ids  = [aws_security_group.rds_sg.id]
+  db_subnet_group_name    = aws_db_subnet_group.db.name
+  backup_retention_period = 7 # Remove automated snapshots after 7 days
+  backup_window           = "03:00-04:00" # 11PM EST
 }


### PR DESCRIPTION
## module-name: 
Deploy infrastructure changes to sandbox automatically

### Jira Ticket

n/a

## Problem

I want to automate updating infrastructure, deploying the API, automate performing migrations against the database , etc but I need to be able to assume a role in the sandbox environment to do so.

## Solution

Within AWS, I manually configured an OIDC provider that allows an AWS assume-role action from this repo specifically to assume a role specifically meant for deploying infrastructure.

Then, I added a `deploy-to-sandbox.yml` workflow that currently:
- assumes a role in AWS
- initializes terraform, then checks if any new infrastructure needs to be created
- if so, creates it

In higher environments, we can add more process to this (require the plan to reviewed by a human before it is executed) but this is a good start.

## Result

terraform changes will be applied automatically

## Test Plan

merge this PR!
