### PR TITLE
the whitespace before ] is significant

### DIFF
--- a/infrastructure/ctkey.sh
+++ b/infrastructure/ctkey.sh
@@ -5,11 +5,11 @@ PROFILE_NAME=ecs-pg-app
 AWS_REGION=us-gov-west-1
 IAM_ROLE=ct-ado-dsac-application-admin
 
-if [ -z "$CTKEY_USERNAME"]; then
+if [ -z "$CTKEY_USERNAME" ]; then
     read -p "Enter ctkey username: " CTKEY_USERNAME
 fi
 
-if [ -z "$CTKEY_PASSWORD"]; then
+if [ -z "$CTKEY_PASSWORD" ]; then
     read -s -p "Enter password for $CTKEY_USERNAME: " CTKEY_PASSWORD
 fi
 


### PR DESCRIPTION
## module-name: Update ctkey script again

### Jira Ticket # n/a

## Problem

Using ctkey script prints an error message related to the closing bracket. The whitespace is significant!

https://stackoverflow.com/questions/9581064/why-should-there-be-spaces-around-and-in-bash

## Solution

Add spaces before ] in the tests in ctkey.sh

## Result

ctkey.sh no longer reports a syntax error

## Test Plan

try to assume a role using ctkey.sh