### PR TITLE
Auto Reload for docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 *.pot
 *.pyc
+*.djcache
 __pycache__/
 local_settings.py
 db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 media
+djcache/
 
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.

--- a/backend/.env_template
+++ b/backend/.env_template
@@ -9,4 +9,4 @@ DEBUG=True
 DJANGO_ALLOWED_HOSTS=['localhost', '127.0.0.1']
 DJANGO_LOGLEVEL='WARNING'
 NPD_PROJECT_NAME='[Project Name]'
-CACHE_LOCATION = ''
+CACHE_LOCATION = '/tmp/django_cache' # Add this to cleanly handle .djcache files for auto-reload

--- a/backend/.env_template
+++ b/backend/.env_template
@@ -9,4 +9,3 @@ DEBUG=True
 DJANGO_ALLOWED_HOSTS=['localhost', '127.0.0.1']
 DJANGO_LOGLEVEL='WARNING'
 NPD_PROJECT_NAME='[Project Name]'
-CACHE_LOCATION = '/tmp/django_cache' # Add this to cleanly handle .djcache files for auto-reload

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -175,6 +175,6 @@ DEBUG_TOOLBAR_CONFIG = {
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": config('CACHE_LOCATION'),
+        "LOCATION": "./djcache",
     }
 }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -53,8 +53,6 @@ services:
       - .env
     volumes:
       - '.:/app'
-      - '/app/node_modules'
-      - '/app/__pycache__'
 volumes:
   postgres_data:
 networks:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       NPD_DB_PORT: ${NPD_DB_PORT}
     env_file:
       - .env
+    volumes:
+      - '.:/app'
+      - '/app/node_modules'
+      - '/app/__pycache__'
 volumes:
   postgres_data:
 networks:


### PR DESCRIPTION
## Auto Reload for docker-compose

## Problem

When running `/backend `with `docker-compose up --build`, you have to manually stop the server anytime you make code changes creating dev burden.

## Solution

Add volume mounts to bind your source code to the container.

## Result

Any changes to your code will be reflected in the server automatically meaning no more stopping and running loops.

## Test Plan

1. run `docker-compose up --build`
2. go to any endpoint
3. make changes
4. check to see if endpoint changes are reflected automatically
