### PR TITLE
different cache location

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -176,6 +176,6 @@ DEBUG_TOOLBAR_CONFIG = {
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "./djcache",
+        "LOCATION": "/var/tmp/django_cache",
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Different cache location

### Jira Ticket #

## Problem

We don't even need to have cache files show up in the /backend dir at all if we use this path

## Solution

changed the cache location path

## Test Plan

If you delete the djcache folder and run `docker-compose up --build`, you'll notice that no new cache directory is created.