### PR TITLE
disable django login for swagger auth

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -169,6 +169,10 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 
+SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': False
+}
+
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': lambda request: DEBUG
 }


### PR DESCRIPTION
## module-name: remove swagger authn requirement

### Jira Ticket # NDH-227

## Problem

Django prompts the user to login when trying to view the swagger documentation at http://ndh-alb-1866093491.us-gov-west-1.elb.amazonaws.com/fhir/docs/

## Solution

Following https://stackoverflow.com/questions/62031565/how-to-disable-django-login-page-when-trying-to-access-swagger-api-in-browser/62584075#62584075, configures Django to not require an active user session to view the swagger docs page

## Result

User can load the swagger docs page at http://ndh-alb-1866093491.us-gov-west-1.elb.amazonaws.com/fhir/docs/

## Test Plan

User can load the swagger docs page at http://ndh-alb-1866093491.us-gov-west-1.elb.amazonaws.com/fhir/docs/