### PR TITLE
configure logging such that 500s and such are logged to stdout

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from decouple import config
 import os
 import sys
+import logging
 
 # Detect if tests are being run
 TESTING = 'test' in sys.argv
@@ -179,6 +180,28 @@ CACHES = {
         "LOCATION": "/var/tmp/django_cache",
     }
 }
+
 SWAGGER_SETTINGS = {
     'USE_SESSION_AUTH': False
+}
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", logging.INFO)
+LOGGING = {
+    "version": 1,
+    # This will leave the default Django logging behavior in place
+    "disable_existing_loggers": False,
+    # Custom handler config that gets log messages and outputs them to console
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": LOG_LEVEL,
+        },
+    },
+    "loggers": {
+        # Send everything to console
+        "": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+        },
+    },
 }


### PR DESCRIPTION
http://ndh-alb-1866093491.us-gov-west-1.elb.amazonaws.com/fhir/Organization is responding with a 500 and I don't have enough logging to troubleshoot. I'm reading that when DEBUG is off, Django wants to email an admin the error.

<img width="1285" height="638" alt="image" src="https://github.com/user-attachments/assets/92e95de2-ee87-4b43-8a5f-03d32ac90934" />

This PR updates the logging configuration to include the stack trace in logs:

<img width="1285" height="638" alt="image" src="https://github.com/user-attachments/assets/47572338-992c-4ac0-8bd4-62a67cc57932" />

Eventually we want to instrument the API with Datadog or similar, but this is enough to start.
