### PR TITLE
Fixing broken endpoint due to validation 

### DIFF
--- a/backend/npdfhir/serializers.py
+++ b/backend/npdfhir/serializers.py
@@ -253,13 +253,6 @@ class EndpointIdentifierSerialzier(serializers.Serializer):
     def to_representation(self, instance):
         endpoint_identifier = Identifier(
             use="official",
-            type=CodeableConcept(
-                coding=[Coding(
-                    system="http://terminology.hl7.org/CodeSystem/v2-0203",
-                    code="ANON", # value left as this for now ~ not correct
-                    display="Anopnymous Idenfitifer" # value left as this for now ~ not correct
-                )]
-            ),
             system=instance.system,
             value=instance.other_id,
             assigner=Reference(display=str(instance.issuer_id)) # TODO: Replace with Organization reference

--- a/backend/npdfhir/views.py
+++ b/backend/npdfhir/views.py
@@ -63,7 +63,6 @@ class FHIREndpointViewSet(viewsets.ViewSet):
         responses={200: "Successful response",
                    404: "Error: The requested Endpoint resource cannot be found."}
     )
-    
     def list(self, request):
         """
         Returns a list of all endpoints as FHIR Endpoint resources


### PR DESCRIPTION
## Fixing broken endpoint due to validation 

## Problem

Endpoint endpoint was failing because I left the Identifier resource empty which failed validation tests

## Solution

Implemented a default of ANON for Code and Display within EndpointIdenfifierSerializer

## Result

Endpoint endpoint works as it should

Some important notes regarding the summary line:

* I just randomly chose ANON but can change it to what makes more sense as a default code
* I will implement this into testing for this endpoint but i wonder if we should have CI tests that run these validation checks every time someone is working on the API

## Test Plan

Run docker-compose up --build and hit endpoint.
