### PR TITLE
[NDH-301] Address frontend dependency management

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -65,7 +65,8 @@ services:
       - '8000:8000'
     volumes:
       - '.:/app'
-      - ./artifacts:/app/artifacts
+      - ./artifacts:/app/artifacts:rw
+      - ./provider_directory/static:/app/provider_directory/static:rw
     depends_on:
       - db
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@cmsgov/design-system": "^13.0.0",
         "@uswds/uswds": "3.13.0",
         "classnames": "^2.5.1",
+        "i18next": "^25.6.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.9.4"
@@ -5958,6 +5959,37 @@
         "node": ">= 14"
       }
     },
+    "node_modules/i18next": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.6.0.tgz",
+      "integrity": "sha512-tTn8fLrwBYtnclpL5aPXK/tAYBLWVvoHM1zdfXoRNLcI+RvtMsoZRV98ePlaW3khHYKuNh/Q65W/+NVFUeIwVw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8013,7 +8045,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@cmsgov/design-system": "^13.0.0",
     "@uswds/uswds": "3.13.0",
     "classnames": "^2.5.1",
+    "i18next": "^25.6.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router": "^7.9.4"


### PR DESCRIPTION
## NPD Frontend: add i18next for content management, address frontend dependencies in docker

[Jira ticket NDH-301](https://jiraent.cms.gov/browse/NDH-301)

## Problem

We have noticed that when a new frontend dependency is added with `npm install --save $dep`, it is not available after running `docker compose build web`. 

## Solution

It turns out that's just how docker + docker compose work.

We're mounting a virtual volume into the `web` service container in place of the `/app/node_modules` directory. This means that our Dockerfile runs `npm install` with one version of `/app/node_modules` and then  `docker compose run web` starts the new image and mounts a _different_, persistent volume at the same location inside the container at runtime.

This mount is useful because it allows `node_modules` to persist across different versions of the frontend service image, it prevents your host `frontend/node_modules` directory from interfering with the container `/app/node_modules`, and finally `docker compose run npm install` commands are faster and persistent because they write to and read from the same volume.

Unfortunately, `docker compose build` doesn't know about the named volume created and mounted in `frontend/docker-compose.yml`, and `docker compose run` doesn't know about the transient `/app/node_modules` included in the `web` service's image.

I added documentation covering this situation.

## Result

If you are running the frontend with docker compose, you'll need to run `docker compose run web npm install` to update  dependencies.