### PR TITLE
[NDH-296] Use i18next as a frontend content / translation helper

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,26 @@ If we find this approach to be insufficient, we will assess additional API endpo
   - `assets/` contains static assets
   - `components/` contains custom components
   - `hooks/` contains custom hook implementations
+  - `i18n/en/` contains translation / static content definition files
+
+### Static Content
+
+Any static content which appears on a page as part of a React HTML or other component tag should be stored in the appropriate `src/i18/**/*.json` source file and accessed via the [react-i18next](https://react.i18next.com/) `t()` function. This allows us to isolate content from behavior and will allow for easier translation in the future, should the need arise.
+
+We recommend using the `useTranslation` hook to access the `t()` function. For example:
+
+```tsx
+const MyComponent = () => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="ds-u-display--flex">
+      <p>{t("component.disclaimer")}</p>
+      <p><a href="#">{t("component.link")}</a></p>
+    </div>
+  )
+}
+```
 
 ## Local Development
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,8 +12,10 @@
         "@uswds/uswds": "3.13.0",
         "classnames": "^2.5.1",
         "i18next": "^25.6.0",
+        "i18next-browser-languagedetector": "^8.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-i18next": "^16.1.2",
         "react-router": "^7.9.4"
       },
       "devDependencies": {
@@ -1335,16 +1337,25 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
+      "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.2.tgz",
-      "integrity": "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.0.tgz",
+      "integrity": "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.1",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/figures": "^1.0.14",
+        "@inquirer/type": "^3.0.9",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1360,13 +1371,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.16.tgz",
-      "integrity": "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==",
+      "version": "5.1.19",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.19.tgz",
+      "integrity": "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1381,14 +1392,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
-      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.1",
+        "@inquirer/figures": "^1.0.14",
+        "@inquirer/type": "^3.0.9",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -1408,14 +1419,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.18.tgz",
-      "integrity": "sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
+      "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/external-editor": "^1.0.1",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1430,13 +1441,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.18.tgz",
-      "integrity": "sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.21.tgz",
+      "integrity": "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1452,13 +1463,13 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
-      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.0",
-        "iconv-lite": "^0.6.3"
+        "iconv-lite": "^0.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -1472,23 +1483,39 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
+      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.2.tgz",
-      "integrity": "sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.5.tgz",
+      "integrity": "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1503,13 +1530,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.18.tgz",
-      "integrity": "sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.21.tgz",
+      "integrity": "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1524,14 +1551,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.18.tgz",
-      "integrity": "sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.21.tgz",
+      "integrity": "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2"
+        "@inquirer/ansi": "^1.0.1",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1546,21 +1573,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.4.tgz",
-      "integrity": "sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.9.0.tgz",
+      "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.2.2",
-        "@inquirer/confirm": "^5.1.16",
-        "@inquirer/editor": "^4.2.18",
-        "@inquirer/expand": "^4.0.18",
-        "@inquirer/input": "^4.2.2",
-        "@inquirer/number": "^3.0.18",
-        "@inquirer/password": "^4.0.18",
-        "@inquirer/rawlist": "^4.1.6",
-        "@inquirer/search": "^3.1.1",
-        "@inquirer/select": "^4.3.2"
+        "@inquirer/checkbox": "^4.3.0",
+        "@inquirer/confirm": "^5.1.19",
+        "@inquirer/editor": "^4.2.21",
+        "@inquirer/expand": "^4.0.21",
+        "@inquirer/input": "^4.2.5",
+        "@inquirer/number": "^3.0.21",
+        "@inquirer/password": "^4.0.21",
+        "@inquirer/rawlist": "^4.1.9",
+        "@inquirer/search": "^3.2.0",
+        "@inquirer/select": "^4.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -1575,13 +1602,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.6.tgz",
-      "integrity": "sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.9.tgz",
+      "integrity": "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/type": "^3.0.8",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/type": "^3.0.9",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1597,14 +1624,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.1.tgz",
-      "integrity": "sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.0.tgz",
+      "integrity": "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/figures": "^1.0.14",
+        "@inquirer/type": "^3.0.9",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1620,15 +1647,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.2.tgz",
-      "integrity": "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.0.tgz",
+      "integrity": "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.1",
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/figures": "^1.0.14",
+        "@inquirer/type": "^3.0.9",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1644,9 +1671,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
+      "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4622,21 +4649,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -5931,6 +5943,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5990,10 +6011,20 @@
         }
       }
     },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6075,15 +6106,15 @@
       "license": "ISC"
     },
     "node_modules/inquirer": {
-      "version": "12.9.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.4.tgz",
-      "integrity": "sha512-5bV3LOgLtMAiJq1QpaUddfRrvaX59wiMYppS7z2jNRSQ64acI0yqx7WMxWhgymenSXOyD657g9tlsTjqGYM8sg==",
+      "version": "12.9.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.6.tgz",
+      "integrity": "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.2.0",
-        "@inquirer/prompts": "^7.8.4",
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/prompts": "^7.8.6",
         "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
         "mute-stream": "^2.0.0",
         "run-async": "^4.0.5",
         "rxjs": "^7.8.2"
@@ -7161,6 +7192,32 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.1.2.tgz",
+      "integrity": "sha512-AxZAojM6CsP9qWUu8d0XD0KXYBG6yyitcWRRPSRXgGVkJ47hCIy3Mc/sE9deB0k+OK9WcC04vSFoQC9QdMcd6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.5.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8029,18 +8086,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -8355,6 +8400,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "watch": "vite build --watch",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "format": "npx prettier . --write",
     "preview": "vite preview",
     "test-watch": "vitest",
@@ -19,8 +20,10 @@
     "@uswds/uswds": "3.13.0",
     "classnames": "^2.5.1",
     "i18next": "^25.6.0",
+    "i18next-browser-languagedetector": "^8.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-i18next": "^16.1.2",
     "react-router": "^7.9.4"
   },
   "devDependencies": {

--- a/frontend/src/@types/i18n.d.ts
+++ b/frontend/src/@types/i18n.d.ts
@@ -1,0 +1,12 @@
+import { defaultNS, resources } from "../i18n"
+
+// NOTE: (@abachman-dsac) this is based on documentation from
+// https://www.i18next.com/overview/typescript#create-a-declaration-file
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    defaultNS: typeof defaultNS
+    resources: typeof resources
+    strictKeyChecks: true
+  }
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,8 +1,11 @@
 import classNames from "classnames"
+import { useTranslation } from "react-i18next"
 import logoImgSrc from "../assets/hss-logo.png"
 import styles from "./Footer.module.css"
 
 const FooterLogo = () => {
+  const { t } = useTranslation()
+
   const classes = classNames(
     "ds-u-display--flex",
     "ds-u-flex-direction--row",
@@ -13,17 +16,16 @@ const FooterLogo = () => {
     <div className={classes}>
       <img src={logoImgSrc} className={styles.logoImg} alt="HHS Logo" />
       <div className={styles.logoText}>
-        <p>
-          A federal government website managed and paid for by the U.S. Centers
-          for Medicare & Medicaid Services.
-        </p>
-        <p>7500 Security Boulevard, Baltimore, MD 21244</p>
+        <p>{t("footer.logo.disclaimer")}</p>
+        <p>{t("footer.logo.address")}</p>
       </div>
     </div>
   )
 }
 
 export const Footer = () => {
+  const { t } = useTranslation()
+
   const linkHeaderClasses = classNames(
     "usa-footer__primary-link",
     "ds-u-padding-top--0",
@@ -37,21 +39,27 @@ export const Footer = () => {
             <FooterLogo />
           </div>
           <div className="ds-l-col--2">
-            <h4 className={linkHeaderClasses}>National Provider Directory</h4>
+            <h4 className={linkHeaderClasses}>
+              {t("footer.section.npd.title")}
+            </h4>
             <ul className="usa-list usa-list--unstyled">
-              <a href="#">Footer link</a>
+              <a href="#">{t("footer.section.npd.link.demo")}</a>
             </ul>
           </div>
           <div className="ds-l-col--2">
-            <h4 className={linkHeaderClasses}>CMS & HHS Websites</h4>
+            <h4 className={linkHeaderClasses}>
+              {t("footer.section.cms.title")}
+            </h4>
             <ul className="usa-list usa-list--unstyled">
-              <a href="#">Footer link</a>
+              <a href="#">{t("footer.section.cms.link.demo")}</a>
             </ul>
           </div>
           <div className="ds-l-col--2">
-            <h4 className={linkHeaderClasses}>Additional Information</h4>
+            <h4 className={linkHeaderClasses}>
+              {t("footer.section.info.title")}
+            </h4>
             <ul className="usa-list usa-list--unstyled">
-              <a href="#">Footer link</a>
+              <a href="#">{t("footer.section.info.link.demo")}</a>
             </ul>
           </div>
         </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,17 +1,18 @@
 import { Badge, SkipNav, UsaBanner } from "@cmsgov/design-system"
 import classnames from "classnames"
+import { useTranslation } from "react-i18next"
 
 import close from "@uswds/uswds/img/usa-icons/close.svg"
-
 import cmsLogo from "../assets/cms-gov-logo.svg"
 import styles from "./Header.module.css"
 
 function Header() {
+  const { t } = useTranslation()
   const classes = classnames("usa-header", "usa-header--basic", styles.header)
 
   return (
     <>
-      <SkipNav href="#">Skip navigation</SkipNav>
+      <SkipNav href="#">{t("header.skip")}</SkipNav>
       <UsaBanner />
       <header className={classes} role="banner">
         <div className="usa-nav-container">
@@ -19,10 +20,10 @@ function Header() {
             <div className={`usa-logo ${styles.title}`}>
               <img src={cmsLogo} className={styles.logo} alt="CMS.gov" />
               <em className={`${styles.logoText} usa-logo__text `}>
-                National Provider Directory
+                {t("header.title")}
               </em>
               <Badge variation="info" className={styles.betaBadge}>
-                BETA
+                {t("header.badge")}
               </Badge>
             </div>
             <button type="button" className="usa-menu-btn">
@@ -38,7 +39,7 @@ function Header() {
             <ul className="usa-nav__primary usa-accordion" role="navigation">
               <li className="usa-nav__primary-item">
                 <a href="#" className="usa-nav-link">
-                  Search the data
+                  {t("header.link.search")}
                 </a>
               </li>
               <li className="usa-nav__primary-item">
@@ -48,7 +49,7 @@ function Header() {
                   aria-expanded="false"
                   aria-controls="basic-nav-section"
                 >
-                  <span>For developers</span>
+                  <span>{t("header.link.developers")}</span>
                 </button>
                 <ul
                   id="basic-nav-section"
@@ -58,34 +59,24 @@ function Header() {
                 >
                   <li className="usa-nav__submenu-item">
                     <a href="javascript:void(0);">
-                      <span>Overview</span>
+                      <span>{t("header.menu.developers.overview")}</span>
                     </a>
                   </li>
                   <li className="usa-nav__submenu-item">
                     <a href="javascript:void(0);">
-                      <span>About the data</span>
+                      <span>{t("header.menu.developers.about")}</span>
                     </a>
                   </li>
                   <li className="usa-nav__submenu-item">
                     <a href="javascript:void(0);">
-                      <span>API documentation</span>
-                    </a>
-                  </li>
-                  <li className="usa-nav__submenu-item">
-                    <a href="javascript:void(0);">
-                      <span>Bulk data files</span>
-                    </a>
-                  </li>
-                  <li className="usa-nav__submenu-item">
-                    <a href="javascript:void(0);">
-                      <span>Developer support</span>
+                      <span>{t("header.menu.developers.api")}</span>
                     </a>
                   </li>
                 </ul>
               </li>
               <li className="usa-nav__primary-item">
                 <a href="#" className="ds-u-link">
-                  For providers
+                  {t("header.link.providers")}
                 </a>
               </li>
             </ul>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,37 @@
+import i18n from "i18next"
+import LanguageDetector from "i18next-browser-languagedetector"
+import { initReactI18next } from "react-i18next"
+
+import { translations } from "./i18n/en"
+
+export const defaultNS = "translations"
+export const resources = {
+  en: {
+    translations,
+  },
+} as const
+
+// run `npm run dev` with DEBUG_I18N=1 set to get i18next debugging
+const debug = !!import.meta.env.DEBUG_I18N
+
+i18n
+  // detect user language
+  // learn more: https://github.com/i18next/i18next-browser-languageDetector
+  .use(LanguageDetector)
+  // pass the i18n instance to react-i18next.
+  .use(initReactI18next)
+  // init i18next
+  // for all options read: https://www.i18next.com/overview/configuration-options
+  .init({
+    lng: "en",
+    supportedLngs: ["en"],
+    fallbackLng: "en",
+    debug,
+    defaultNS,
+    resources,
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  })
+
+export default i18n

--- a/frontend/src/i18n/en/footer.json
+++ b/frontend/src/i18n/en/footer.json
@@ -1,0 +1,27 @@
+{
+  "logo": {
+    "disclaimer": "A federal government website managed and paid for by the U.S. Centers for Medicare & Medicaid Services.",
+    "address": "7500 Security Boulevard, Baltimore, MD 21244"
+  },
+
+  "section": {
+    "npd": {
+      "title": "National Provider Directory",
+      "link": {
+        "demo": "Footer link"
+      }
+    },
+    "cms": {
+      "title": "CMS & HHS Websites",
+      "link": {
+        "demo": "Footer link"
+      }
+    },
+    "info": {
+      "title": "Additional Information",
+      "link": {
+        "demo": "Footer link"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/en/header.json
+++ b/frontend/src/i18n/en/header.json
@@ -1,0 +1,17 @@
+{
+  "skip": "Skip navigation",
+  "title": "National Provider Directory",
+  "badge": "BETA",
+  "link": {
+    "search": "Search the data",
+    "developers": "For developers",
+    "providers": "For providers"
+  },
+  "menu": {
+    "developers": {
+      "overview": "Overview",
+      "about": "About the data",
+      "api": "API documentation"
+    }
+  }
+}

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,0 +1,33 @@
+// components
+import footer from "./footer.json"
+import header from "./header.json"
+
+// pages
+import landing from "./landing.json"
+
+/*
+ * NOTE: (@abachman-dsac) a word about i18n usage in react components and the
+ * names of keys
+ *
+ * Keys definied here use the root-level key shown below plus whatever hierarchy
+ * is defined in the corresponding JSON file.
+ *
+ * For example, given header.json:
+ *
+ *   { "section": { "title": "Blah Section" } }
+ *
+ * The TFunction would reference that value with:
+ *
+ *   t('header.section.title')
+ *
+ * Due to the use of `header` in the `translations` object here, and the direct
+ * handing of `translations` to the i18n configuration.
+ *
+ * Also, the use of "translations" as the defaultNS in i18n.ts necessitates its
+ * use here.
+ */
+export const translations = {
+  header,
+  footer,
+  landing,
+}

--- a/frontend/src/i18n/en/landing.json
+++ b/frontend/src/i18n/en/landing.json
@@ -1,0 +1,14 @@
+{
+  "badge": "LIMITED-RELEASE BETA",
+  "title": "National Provider Directory",
+  "tagline": "Building the new infrastructure for health data interoperability",
+  "about": {
+    "title": "About the directory",
+    "description": "The National Provider Directory uses data from multiple publicly-available data sources and combines them to create a trusted source of truth for information about healthcare providers."
+  },
+  "links": {
+    "developers": "Developer resources",
+    "providers": "Provider resources",
+    "learn": "Learn how it works"
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,6 +14,8 @@ import "@uswds/uswds/css/uswds.css"
 // USWDS javascript behaviors
 import "@uswds/uswds"
 
+import "./i18n.ts"
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -2,9 +2,13 @@ import Header from "../components/Header"
 
 import { Badge, Button, SkipNav } from "@cmsgov/design-system"
 import { Footer } from "../components/Footer"
+
+import { useTranslation } from "react-i18next"
 import styles from "./Landing.module.css"
 
 export const Landing = () => {
+  const { t } = useTranslation()
+
   return (
     <>
       <SkipNav href="#main-content" />
@@ -16,21 +20,18 @@ export const Landing = () => {
             <div className="ds-l-row">
               <div className="ds-l-col--12">
                 <Badge variation="info" className={styles.heroBadge}>
-                  LIMITED-RELEASE BETA
+                  {t("landing.badge")}
                 </Badge>
 
-                <h1>National Provider Directory</h1>
-                <p className={styles.tagline}>
-                  Building the new infrastructure for health data
-                  interoperability
-                </p>
+                <h1>{t("landing.title")}</h1>
+                <p className={styles.tagline}>{t("landing.tagline")}</p>
 
                 <div className={styles.primaryActions}>
                   <Button variation="solid" href="/developers">
-                    Developer resources
+                    {t("landing.links.developers")}
                   </Button>
                   <Button variation="solid" href="/providers">
-                    Provider information
+                    {t("landing.links.providers")}
                   </Button>
                 </div>
               </div>
@@ -44,16 +45,13 @@ export const Landing = () => {
         <div className="ds-l-row">
           <div className="ds-l-col--12">
             <div className={styles.secondary}>
-              <h2>About the directory</h2>
+              <h2>{t("landing.about.title")}</h2>
 
               <p className={styles.secondaryDescription}>
-                The National Provider Directory uses data from multiple
-                publicly-available data sources and combines them to create a
-                trusted source of truth for information about healthcare
-                providers.
+                {t("landing.about.description")}
               </p>
 
-              <Button href="#">Learn how it works</Button>
+              <Button href="#">{t("landing.links.learn")}</Button>
             </div>
           </div>
         </div>

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -3,6 +3,9 @@ import "@testing-library/jest-dom/vitest"
 import { cleanup } from "@testing-library/react"
 import { afterEach, expect } from "vitest"
 
+// ensure translations are supported
+import "../src/i18n"
+
 expect.extend(matchers)
 
 afterEach(() => {


### PR DESCRIPTION
## frontend content: Use a translation helper to manage static content in the frontend

[Jira Ticket NDH-296](https://jiraent.cms.gov/browse/NDH-296)

## Problem

We would prefer not to embed any static content in our frontend React components, whenever possible.

Keeping content separate from implementation makes our React components simpler and will make review of static content easier in the future.

## Solution

Pulling from the example of other CMS open source work, for example: 

- https://github.com/CMSgov/design-system
- https://github.com/CMSgov/hcgov-design-system
- https://github.com/CMS-Enterprise/mint-app
- https://github.com/CMS-Enterprise/easi-app

I am introducing the `i18next` and `react-i18next` libraries to support dynamic content loading on frontend pages. 

## Result

Content is stored in JSON files currently located in `frontend/src/i18n/en/`.

The `i18next.t` function is utilized via the `useTranslation()` React hook. 

You can see examples of usage in the Header and Footer components and Landing page.

I added documentation describing namespaces / key resolution to the base resources file in `frontend/src/i18n/en/index.ts` and developer documentation to `frontend/README.md`.

## Test Plan

The frontend test suite continues to run green and typescript isn't complaining. 

### Future Work

Make typescript get at least a _little_ bit complain-y when invalid keys are used with `t('key')`. I explored a few solutions, but didn't find anything that immediately clicked. 