### PR TITLE
[NDH-295]: Fix header nav menu accessibility issues

### DIFF
--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -39,3 +39,8 @@
   margin-left: 0.5rem;
   padding: var(--spacer-half, 0.25rem) var(--spacer-1, 0.5rem);
 }
+
+.submenuList a:focus {
+  background-color: transparent !important;
+  outline: 0.25rem solid #2591ff !important;
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -52,7 +52,7 @@ function Header() {
                 </button>
                 <ul
                   id="basic-nav-section"
-                  className="usa-nav__submenu"
+                  className={`usa-nav__submenu ${styles.submenuList}`}
                   role="menu"
                   hidden
                 >


### PR DESCRIPTION
## Fix header nav menu accessibility issues

### Jira Ticket [#295](https://jiraent.cms.gov/browse/NDH-295)

## Problem
When focusing links, the text color matches the background color, violating sec 508, which requires a color contrast ratio of at least 4.5:1

## Solution
Implement a new CSS module to that overwrites the default styling to apply the USWDS `blue-40v` focus indicator styling

## Result
Tabbing through the menu lets you see the focused item clearly

## Test Plan
- run docker compose up --build 
- go to localhost:3000
- tab through For Developer in nav bar
