### PR TITLE
NDH-326 Clarify FHIR Version for Base Validator

### DIFF
--- a/backend/npdfhir/tests.py
+++ b/backend/npdfhir/tests.py
@@ -1,7 +1,7 @@
 from django.db import connection
 from django.test.runner import DiscoverRunner
 from django.urls import reverse
-from fhir.resources.bundle import Bundle
+from fhir.resources.R4B.bundle import Bundle
 from pydantic import ValidationError
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
@@ -109,7 +109,7 @@ class EndpointViewSetTestCase(APITestCase):
         first_endpoint = entries[0]["resource"]
         self.assertIn("connectionType", first_endpoint)
 
-        code = first_endpoint["connectionType"][0]["coding"][0]["code"]
+        code = first_endpoint["connectionType"]["code"]
         self.assertEqual(connection_type, code)
 
     def test_filter_returns_empty_for_nonexistent_name(self):

--- a/backend/npdfhir/utils.py
+++ b/backend/npdfhir/utils.py
@@ -1,11 +1,11 @@
-from fhir.resources.address import Address
+from fhir.resources.R4B.address import Address
 
 
 def SmartyStreetstoFHIR(address):
-    addressLine1=f"{address.address_us.primary_number} {address.address_us.street_predirection} {address.address_us.street_name} {address.address_us.postdirection} {address.address_us.street_suffix}"
-    addressLine2=f"{address.address_us.secondary_designator} {address.address_us.secondary_number}"
-    addressLine3=f"{address.address_us.extra_secondary_designator} {address.address_us.extra_secondary_number}"
-    cityStateZip=f"f{address.address_us.city_name}, {address.address_us.fips_state.state_abbreviation} {address.address_us.zipcode}"
+    addressLine1 = f"{address.address_us.primary_number} {address.address_us.street_predirection} {address.address_us.street_name} {address.address_us.postdirection} {address.address_us.street_suffix}"
+    addressLine2 = f"{address.address_us.secondary_designator} {address.address_us.secondary_number}"
+    addressLine3 = f"{address.address_us.extra_secondary_designator} {address.address_us.extra_secondary_number}"
+    cityStateZip = f"f{address.address_us.city_name}, {address.address_us.fips_state.state_abbreviation} {address.address_us.zipcode}"
     return Address(
         line=[addressLine1, addressLine2, addressLine3, cityStateZip],
         use=address.address_type.value


### PR DESCRIPTION
…it that we're using FHIR v4

<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: NDH-326 Clarify FHIR Version for Base Validator

### Jira Ticket #NDH-326

## Problem

The meeting with Alberto this morning, in which we discussed fhir profiles and validators, made me. realize that the code was conflating a few implementation guides and FHIR versions. We need to be more explicit/consistent about which base FHIR version we're using and where we're layering on top of it.

## Solution

This PR is a starting point, that takes us down to brass tacks with a v4 FHIR base implementation. From here, we can layer in extensions on the validators that make it clearer where we're relying on other fhir profiles/ IGs. 

## Result

* Explicitly imports the FHIR v4 base validator from `fhir.resources` instead of the most recent version
* Makes some tweaks to bring the serializers into conformance with the v4 base FHIR spec
* Updates the tests accordingly

## Test Plan

1. navigate to `/backend`
2. run `make test`
3. all tests should pass!

Note: This is a little messy but will get cleaned up as we layer the explicit us core/ ndh/ plan net validators in
