### PR TITLE
ndh-286: add database check to healthCheck endpoint; update unit test

### DIFF
--- a/backend/npdfhir/middleware.py
+++ b/backend/npdfhir/middleware.py
@@ -33,7 +33,6 @@ class HealthCheckMiddleware:
                 health_status.update({
                     'status': 'unhealthy',
                     'database': 'disconnected',
-                    'error': str(e)
                 })
                 return JsonResponse(health_status, status=502)
 

--- a/backend/npdfhir/tests.py
+++ b/backend/npdfhir/tests.py
@@ -5,7 +5,6 @@ from fhir.resources.R4B.bundle import Bundle
 from pydantic import ValidationError
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
-import json
 
 # I can't explain why, but we need to import cacheData here. I think we can remove this once we move to the docker db setup
 from .cache import cacheData
@@ -161,7 +160,7 @@ class BasicViewsTestCase(APITestCase):
     def test_health_view(self):
         url = reverse("healthCheck")  # maps to "/healthCheck"
         response = self.client.get(url)
-        res_obj = json.loads(response.content.decode())
+        res_obj = response.json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(res_obj['status'], "healthy")
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: One line description of your change (less than 72 characters)

### Jira Ticket #286

## Problem

The health check endpoint does not check database connectivity, except when the application is initially launched

## Solution

Add database check to health check endpoint so it runs whenever the endpoint is called

## Result

Used built-in Django `connection.cursor()` method to run a simple SQL command `SELECT 1` against the database to check for a response. This is a standard method for checking connectivity to a database in a situation where a lightweight response is all that is needed. 

The code is added in the middleware, so that it maintains the exemption from the allowed hosts check that was set up for the health check endpoint in ticket #226.

## Test Plan

Updated the health check endpoint unit test to reflect the new response from the the endpoint, which looks like:

<img width="759" height="150" alt="image" src="https://github.com/user-attachments/assets/1644df94-5130-479f-962e-3272ae895208" />

Tested locally with the database running, and with the database stopped. Expected results:

<img width="1518" height="99" alt="image" src="https://github.com/user-attachments/assets/8141af89-56e7-4494-a63c-21ef122a3c37" />

