### PR TITLE
Fix remote ETL flyway task

### DIFF
--- a/infrastructure/modules/etl/main.tf
+++ b/infrastructure/modules/etl/main.tf
@@ -166,7 +166,7 @@ resource "aws_ecs_task_definition" "dagster_daemon" {
         },
         {
           name = "FLYWAY_TABLE"
-          value = "npd-etl-flyway"
+          value = "npd-api-flyway"
         },
         {
           name = "FLYWAY_BASELINE_VERSION"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Fix remote ETL flyway task

### Jira Ticket #N/A

## Problem

Running the flyway migrations against the remote etl db instance was producing this error:
<img width="720" height="276" alt="image" src="https://github.com/user-attachments/assets/6ed872f3-5bac-4d93-9488-57fe8086608c" />


## Solution

Updated the remote env variables to match @dturner5234's local env, to account for the different table name that he's using to track the schema history.

## Test Plan

1. terraform should initialize successfully
2. after this is merged, the migration should complete successfully
