### PR TITLE
push config for starting dms task

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -24,6 +24,8 @@ locals {
   account_name = "npd-east-${var.tier}"
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_vpc" "default" {
   filter {
     name   = "tag:Name"
@@ -133,6 +135,7 @@ module "etl" {
   dagster_image  = var.dagster_image
   fhir_api_migration_image = var.migration_image
   ecs_cluster_id = module.ecs.cluster_id
+  npd_sync_task_arn = "arn:aws:dms:us-east-1:${data.aws_caller_identity.current.account_id}:replication-config:57J6Z4LH2JAUNKC3LS7RUETZUE"
   db = {
     db_instance_master_user_secret_arn = module.etl-db.db_instance_master_user_secret_arn
     db_instance_address                = module.etl-db.db_instance_address

--- a/infrastructure/modules/etl/main.tf
+++ b/infrastructure/modules/etl/main.tf
@@ -210,6 +210,7 @@ resource "aws_ecs_task_definition" "dagster_daemon" {
       }
       command = ["dagster-daemon", "run"]
       environment = [
+        { name = "NPD_SYNC_REPLICATION_TASK_ARN", value = var.npd_sync_task_arn },
         { name = "S3_REGION", value = "us-east-1" },
         { name = "SKIP_TESTS", value = "True" },
         { name = "S3_DATA_BUCKET", value = aws_s3_bucket.etl_bronze.bucket },
@@ -355,6 +356,7 @@ resource "aws_ecs_task_definition" "dagster_ui" {
       ]
       command = ["dagster-webserver", "--host", "0.0.0.0", "--port", "80"]
       environment = [
+        { name = "NPD_SYNC_REPLICATION_TASK_ARN", value = var.npd_sync_task_arn },
         { name = "SKIP_TESTS", value = "True" },
         { name = "S3_REGION", value = "us-east-1" },
         { name = "S3_DATA_BUCKET", value = aws_s3_bucket.etl_bronze.bucket },

--- a/infrastructure/modules/etl/variables.tf
+++ b/infrastructure/modules/etl/variables.tf
@@ -3,6 +3,7 @@ variable "dagster_home" { default = "/opt/dagster/dagster_home" }
 variable "dagster_image" {}
 variable "fhir_api_migration_image" {}
 variable "ecs_cluster_id" {}
+variable "npd_sync_task_arn" {}
 variable "db" {
   type = object({
     db_instance_master_user_secret_arn = string


### PR DESCRIPTION
## module-name: Configure Dagster Containers to reference a sync task arn

### Jira Ticket #

## Problem

We want to be able to start a DMS sync task from Dagster

## Solution

Expose an environment variable allowing Dagster to start a sync job. The environment variable is a reference to a hand-created resource in the dev environment right now, we'll replace this with something committed to terraform later.

## Result

see above

## Test Plan

Check configuration of task in AWS after deploy