### PR TITLE
increase database class for etl database to t3.large

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -75,7 +75,7 @@ module "etl-db" {
   engine                  = "postgres"
   engine_version          = "17"
   family                  = "postgres17"
-  instance_class          = "db.t3.micro"
+  instance_class          = "db.t3.large"
   allocated_storage       = 100
   publicly_accessible     = false
   username                = "npd_etl"


### PR DESCRIPTION
## module-name: Increase ETL database instance class

### Jira Ticket # n/a

## Problem

ETL database was crashing due to resource usage

## Solution

Increase the size of the etl database from t3.micro to t3.large

## Result

ETL database allocated RAM increases from 1GB to 8GB

## Test Plan

Review state of ETL database instance in RDS