### PR TITLE
adding db storage space

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -56,7 +56,7 @@ module "api-db" {
   engine_version          = "17"
   family                  = "postgres17"
   instance_class          = "db.t3.micro"
-  allocated_storage       = 20
+  allocated_storage       = 100
   publicly_accessible     = false
   username                = "npd"
   db_name                 = "npd"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Adding storage to the api db

### Jira Ticket #N/A

## Problem

Trying to restore the etl db from a backup and running out of space

## Solution

Increases db storage to 100 gb

