### PR TITLE
Add Missing Test for PractitionerRoleViewSetTestCase

### DIFF
--- a/backend/npdfhir/tests.py
+++ b/backend/npdfhir/tests.py
@@ -586,8 +586,6 @@ class PractitionerRoleViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "application/fhir+json")
 
-        #print(response.data["results"]["entry"])
-
         # Extract ids
         ids = [
             d['resource'].get('id', {})


### PR DESCRIPTION
## Add Missing Test for PractitionerRoleViewSetTestCase

### Jira Ticket #NDH-250

## Problem

We are missing a test that tests the sorting of the list of Practioners by their corresponding locations

## Solution

Create a test by checking the ids returned by the endpoint and verifying that they are in the order of their location names.

## Test Plan

Run `make test`
