### PR TITLE
update api db storage type

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -57,6 +57,7 @@ module "api-db" {
   family                  = "postgres17"
   instance_class          = "db.t3.micro"
   allocated_storage       = 100
+  storage_type            = "gp3"
   publicly_accessible     = false
   username                = "npd"
   db_name                 = "npd"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: update api db storage type

### Jira Ticket #N/A

## Problem

We ran out of burst credits while transferring the etl data into the api db.
<img width="374" height="86" alt="image" src="https://github.com/user-attachments/assets/db20824d-8102-4e88-b436-eb295d225060" />

## Solution

This pr changes the storage type from gp2 to gp3 for the api db instance, so we don't have to reply on the burst credits.

Note: I already made this change in AWS so terraform plan should show no rds storage_type change for the api db instance