### PR TITLE
chore: Introduce formatting and linting to our CI workflows

### DIFF
--- a/.github/workflows/autofix-formatting.yml
+++ b/.github/workflows/autofix-formatting.yml
@@ -1,0 +1,36 @@
+name: autofix.ci
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  autofix-formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # frontend
+      - uses: actions/setup-node@v4
+      - name: Format frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run format
+
+      # backend
+      - name: Format backend
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --output-format=github .
+          src: "./backend"
+
+      # commit
+      - name: Save formatting
+        uses: autofix-ci/action@v1

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 100
 
 [format]
-quote-style = "double"
+quote-style = "single"
 indent-style = "space"
 docstring-code-format = true


### PR DESCRIPTION
> [!WARNING]
> For the autofix-ci approach to work, we will have to install the https://autofix.ci/ app for this project. It's free for open-source, but requires payment information :( 
> 
> Check out an alternative approach with [pre-commit](https://pre-commit.com) in #173

## code quality: Add auto-formatting to our github CI workflows for python and javascript

Jira Link: [NDH-359](https://jiraent.cms.gov/browse/NDH-359)

## Problem

Developers should never have to think about formatting. We have tools to solve this.

## Solution

Introduce GitHub Action workflows to auto-format and create a PR with the changes for all Python and Javascript code.

## Result

Consistent formatting within the project over time.

The effect should be the same as if the author ran this before every commit: 

```sh
cd backend 
ruff format .
cd ../frontend
npm run format
```

## Additional notes / Background

I selected two very opinionated tools: [ruff](https://docs.astral.sh/ruff/configuration/) for Python and [prettier](https://prettier.io/) for Javascript / Typescript. 

Ruff is configured in `backend/ruff.toml`.

Prettier is configured in `frontend/.prettierrc.json`.

### Editor setup

> [!TIP]
> Setup your editor to auto-format and trim whitespace on save.

I use this configuration for VS Code:

```json
{
  "editor.formatOnSave": true
  "[python]": {
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true
    "editor.codeActionsOnSave": {
      "source.fixAll.ruff": "explicit",
      "source.organizeImports.ruff": "explicit"
    }
  },
  "[javascript][typescript][typescriptreact][json]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode",
    "editor.codeActionsOnSave": {
      "source.fixAll": "explicit",
      "source.organizeImports": "explicit"
    },
    "editor.insertSpaces": true,
    "editor.tabSize": 2
  },
  "[css]": {
    "editor.suggest.insertMode": "replace",
    "editor.insertSpaces": true,
    "editor.tabSize": 2
  },
  "[yaml]": {
    "editor.tabSize": 2
  }
}
```

With the extensions: 

- `charliermarsh.ruff` for Ruff
- `esbenp.prettier-vscode` for Prettier