### PR TITLE
add provider_credential pk migration and update model

### DIFF
--- a/backend/npdfhir/models.py
+++ b/backend/npdfhir/models.py
@@ -721,6 +721,8 @@ class ProviderRole(models.Model):
 
 
 class ProviderToCredential(models.Model):
+    pk = models.CompositePrimaryKey(
+        'provider_to_taxonomy_id', 'credential_type_id', 'license_number', 'state_code')
     credential_type = models.ForeignKey(CredentialType, models.DO_NOTHING)
     license_number = models.CharField(max_length=20)
     state_code = models.ForeignKey(

--- a/flyway/sql/migrations/V11__add_pk_to_provider_to_credential.sql
+++ b/flyway/sql/migrations/V11__add_pk_to_provider_to_credential.sql
@@ -1,0 +1,2 @@
+alter table ${apiSchema}.provider_to_credential drop constraint if exists pk_provider_to_credential;
+alter table ${apiSchema}.provider_to_credential add constraint pk_provider_to_credential primary key (provider_to_taxonomy_id, credential_type_id, license_number, state_code);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Add pk to provider_credential table if there isn't one

### Jira Ticket # N/A

## Problem

The provider_credential pk seems to have disappeared.

## Solution

add a migration to drop the pk if it exists and create a new one; update the django model accordingly.

## Test Plan

1. nav to `/backend`
2. run `make test`
3. tests should pass. pk should be present.