### PR TITLE
bump etl database storage

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -77,7 +77,7 @@ module "etl-db" {
   engine_version          = "17"
   family                  = "postgres17"
   instance_class          = "db.t3.large"
-  allocated_storage       = 100
+  allocated_storage       = 250
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -75,7 +75,7 @@ module "etl-db" {
   engine_version          = "17"
   family                  = "postgres17"
   instance_class          = "db.t3.large"
-  allocated_storage       = 100
+  allocated_storage       = 250
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"


### PR DESCRIPTION
ETL database is full and refusing connections. Bumping the provisioned storage to 250 GB while we figure out what is taking up the space.