### PR TITLE
Make sure flyway image has the sql/django_reference_data directory

### DIFF
--- a/flyway/Dockerfile
+++ b/flyway/Dockerfile
@@ -3,5 +3,7 @@ FROM flyway/flyway:10
 ADD sql/migrations sql/migrations
 ADD sql/reference_data sql/reference_data
 
-# django_migrations are for use on NPD application hosts only, not ETL
+# django migrations and reference data are for use on NPD application hosts
+# only, not ETL
 ADD sql/django_migrations sql/django_migrations
+ADD sql/django_reference_data sql/django_reference_data


### PR DESCRIPTION
follow-up to #178 

## Problem

The Flyway image doesn't contain the new `flyway/sql/django_reference_data` folder.

In development and CI it worked because `backend/docker-compose.yaml` mounts the whole `flyway/sql` folder as part of the db-migrations service definition.

```yaml
    volumes:
      - '../flyway/sql:/flyway/sql'
```

## Solution

Add `ADD ./sql/django_reference_data ./sql/django_reference_data` to the flyway deployment Dockerfile.

## Result

The Flyway image built for deployment should include all required migrations.