### PR TITLE
Remove schema name from superuser migration

### DIFF
--- a/flyway/sql/django_reference_data/R__1_create_superuser.sql
+++ b/flyway/sql/django_reference_data/R__1_create_superuser.sql
@@ -4,7 +4,7 @@
 -- WARNING: any time this script is run with a new value for
 -- `superuserDefaultPassword`, the INSERT will be attempted.
 INSERT INTO
-    public.auth_user (
+    auth_user (
         password,
         is_superuser,
         username,


### PR DESCRIPTION
## module-name: Update superuser migration

### Jira Ticket #

## Problem

Superuser migration failed to run because it targets an auth table on the public schema, rather than npd, which flyway is directed at in the cloud

## Solution

remove schema name

## Result

migration will run

## Test Plan

after migration runs, log into the admin dashboard
