### PR TITLE
Update security groups for application load balancers to accept port …

### DIFF
--- a/infrastructure/modules/networking/main.tf
+++ b/infrastructure/modules/networking/main.tf
@@ -59,7 +59,7 @@ resource "aws_security_group" "fhir_api_alb_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http_to_fhir_api_alb" {
-  description       = "Accepts connections from the CMS VPN"
+  description       = "Accepts HTTP connections"
   security_group_id = aws_security_group.fhir_api_alb_sg.id
   ip_protocol = "TCP"
   from_port = 80
@@ -68,7 +68,7 @@ resource "aws_vpc_security_group_ingress_rule" "http_to_fhir_api_alb" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https_to_fhir_api_alb" {
-  description       = "Accepts connections from the CMS VPN"
+  description       = "Accepts HTTPS connections"
   security_group_id = aws_security_group.fhir_api_alb_sg.id
   ip_protocol = "TCP"
   from_port = 443
@@ -204,7 +204,7 @@ resource "aws_security_group" "etl_webserver_alb_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http_to_etl_webserver_alb" {
-  description       = "Accepts connections from the CMS VPN"
+  description       = "Accepts HTTP connections"
   security_group_id = aws_security_group.etl_webserver_alb_sg.id
   ip_protocol = "TCP"
   from_port = 80
@@ -213,7 +213,7 @@ resource "aws_vpc_security_group_ingress_rule" "http_to_etl_webserver_alb" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https_to_etl_webserver_alb" {
-  description       = "Accepts connections from the CMS VPN"
+  description       = "Accepts HTTPS connections"
   security_group_id = aws_security_group.etl_webserver_alb_sg.id
   ip_protocol = "TCP"
   from_port = 443


### PR DESCRIPTION
…80 and 443 connections

## module-name: Relax security groups for application load balancers

### Jira Ticket #

## Problem

Various team members and stakeholders can't access the internal routes. It could very well be a Zscaler thing but updating the security groups to not check against the prefix list or cmscloud vpn fixes this in the short-term with minimal risk (all the relevant endpoints are internal anyway)

## Solution

Update security group configuration for FHIR API and Dagster UI internal load balancers.

## Result

Internal users can access the internal routes but external users can't

## Test Plan

deploy and check the routes
