### PR TITLE
bump etl storage capacity to 500

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -77,7 +77,7 @@ module "etl-db" {
   engine_version          = "17"
   family                  = "postgres17"
   instance_class          = "db.t3.large"
-  allocated_storage       = 250
+  allocated_storage       = 500
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -75,7 +75,7 @@ module "etl-db" {
   engine_version          = "17"
   family                  = "postgres17"
   instance_class          = "db.t3.large"
-  allocated_storage       = 250
+  allocated_storage       = 500
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"


### PR DESCRIPTION
The ETL database ran out of storage again (currently specified at 200 GBs), @dturner5234 suggets this is because dagster is tracking metadata for each job run (or logging, or something else). Bumping the size of the database while I look into this.