### PR TITLE
shorten name of replication task

### DIFF
--- a/infrastructure/modules/migrations/main.tf
+++ b/infrastructure/modules/migrations/main.tf
@@ -78,7 +78,7 @@ module "database_migration_service" {
 
   replication_tasks = {
     etl_replication_task = {
-      replication_task_id       = "npd-${var.region}-${var.tier}-etl-replication-task"
+      replication_task_id       = "${local.account_name}-db-repl-task"
       migration_type            = "cdc"
       replication_task_settings = file("${path.module}/configs/task_settings.json")
       table_mappings            = local.table_mappings


### PR DESCRIPTION
The name of the DMS replication task is too long. This is breaking CI.

This PR updates the name of replication task specified in Terraform to be under 38 characters.