### PR TITLE
Spin up API service in production account

### DIFF
--- a/infrastructure/envs/prod/variables.tf
+++ b/infrastructure/envs/prod/variables.tf
@@ -9,5 +9,5 @@ variable "tier" {
 variable "migration_image" { default = "596240962403.dkr.ecr.us-east-1.amazonaws.com/npd-east-prod-fhir-api-migrations:latest" }
 variable "fhir_api_image" { default = "596240962403.dkr.ecr.us-east-1.amazonaws.com/npd-east-prod-fhir-api:latest" }
 variable "dagster_image" { default = "596240962403.dkr.ecr.us-east-1.amazonaws.com/npd-east-prod-dagster:latest" }
-variable "redirect_to_strategy_page" { default = true }
+variable "redirect_to_strategy_page" { default = false }
 variable "fhir_api_private_load_balancer" { default = false }


### PR DESCRIPTION
Changing this variable to true enables the API service in production and disables the redirect to the CMS strategy page.'

The load balancer URL is public (anyone can reach it) but the work to request a domain is outstanding, blocked by an ATO being assigned.