### PR TITLE
[NDH-422] Upgrade to psycopg, use database connection pooling in Django

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -136,7 +136,16 @@ DATABASES = {
             "MIRROR": "default",                 # optional: avoids creating a test DB
         },
         'OPTIONS': {
-            'options': '-c search_path=npd,public'
+            'options': '-c search_path=npd,public',
+            "pool": {
+                # our default gunicorn container configuration only spins up 3 workerse
+                "min_size": 2,
+                "max_size": 4,
+                # boot clients if a pooled connection is not available within 10 seconds
+                "timeout": 10,
+                # after 2 clients are waiting for connections, subsequent requests should immediately fail
+                "max_waiting": 2,
+            },
         }
     }
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,7 +24,9 @@ Jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
-psycopg2-binary==2.9.10
+psycopg==3.2.12
+psycopg_binary==3.2.12
+psycopg-pool==3.2.7
 Pygments==2.19.2
 python-dateutil==2.9.0.post0
 python-decouple==3.8


### PR DESCRIPTION
## django db connection: Use django connection pooling

[Jira Ticket NDH-422](https://jiraent.cms.gov/browse/NDH-422)

## Problem

We are not pooling database connections in Django, which means each request opens a new connection to postgres.

When faced with a database instance which is slow to respond or an access pattern which is otherwise causing some requests to stay open for a long amount of time (e.g., 15 seconds plus) this can result in connections "piling up" instead of timing out quickly.

## Solution

I upgraded the project from `psycopg2` to [`psycopg`](https://pypi.org/project/psycopg/), which is the newer version of the library and is a requirement for connection pooling. 

I added a "sensible" default connection pooling configuration given our current intentions for production container sizing.

[Documentation on the settings is available here.](https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool)

## Result

Our deployed Django application will have a hard cap on the total number of connections to the database it will open. The current max is `containers * 4`. 

Django web application containers will each immediately open 2 database connections and up to 4 total. 

If a new request / client takes longer than 10 seconds to get a connection from the pool it will receive a timeout error and if 2 clients are already waiting for connections, subsequent clients will receive an immediate error.

We can tweak our settings once we see them operating in deployed environments.