### PR TITLE
specify storage autoscaling limits

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -63,6 +63,7 @@ module "api-db" {
   family                  = "postgres17"
   instance_class          = "db.t3.large"
   allocated_storage       = 100
+  max_allocated_storage   = 1000
   storage_type            = "gp3"
   publicly_accessible     = false
   username                = "npd"
@@ -84,6 +85,7 @@ module "etl-db" {
   family                  = "postgres17"
   instance_class          = "db.t3.large"
   allocated_storage       = 500
+  max_allocated_storage   = 1000
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -61,6 +61,7 @@ module "api-db" {
   family                  = "postgres17"
   instance_class          = "db.t3.large"
   allocated_storage       = 100
+  max_allocated_storage   = 1000
   storage_type            = "gp3"
   publicly_accessible     = false
   username                = "npd"
@@ -83,6 +84,7 @@ module "etl-db" {
   family                  = "postgres17"
   instance_class          = "db.t3.large"
   allocated_storage       = 500
+  max_allocated_storage   = 1000
   publicly_accessible     = false
   username                = "npd_etl"
   db_name                 = "npd_etl"


### PR DESCRIPTION
## module-name: specify rds storage autoscaling limits

### Jira Ticket #

## Problem

The ETL database keeps running out of space

## Solution

Enable autoscaling on the RDS instance but set a reasonable upper limit based on what we know about ETL workloads.

## Result

RDS capacity will scale up to 1 terabyte.

## Test Plan

Merge it, keep adding stuff to the RDS, watch for autoscaling event to happen.
