### PR TITLE
[NDH-446] Ensure login header, footer, and body are responsive on mobile

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -26,45 +26,82 @@ const FooterLogo = () => {
 export const Footer = () => {
   const { t } = useTranslation()
 
+  const logoColumnClasses = classNames(
+    "ds-l-md-col--5",
+    "ds-l-sm-col--12",
+    "ds-u-padding-bottom--4",
+    "ds-u-md-padding-bottom--0",
+  )
+
+  const columnClasses = classNames(
+    "ds-l-md-col--2",
+    "ds-l-sm-col--12",
+    "ds-u-padding-y--3",
+    "ds-u-md-padding-y--0",
+  )
+
   const linkHeaderClasses = classNames(
     "usa-footer__primary-link",
-    "ds-u-padding-top--0",
+    "ds-u-padding-top--none",
+    "ds-u-sm-padding-top--1",
+    "ds-u-md-padding-top--0",
+    "ds-u-padding-left--0",
+    "ds-u-margin-top--0",
     "ds-u-margin-top--0",
   )
+
   return (
     <footer className={styles.footer}>
       <section className="ds-l-container">
         <div className="ds-l-row">
-          <div className="ds-l-col--5">
+          <div className={logoColumnClasses}>
             <FooterLogo />
           </div>
-          <div className="ds-l-col--2">
+          <div className={columnClasses}>
             <h4 className={linkHeaderClasses}>
               {t("footer.section.support.title")}
             </h4>
             <ul className="usa-list usa-list--unstyled">
-              {(t("footer.section.support.links", { returnObjects: true }) as Array<{text: string, url: string}>).map((link, i) => (
-                <li key={i}><a href={link.url}>{link.text}</a></li>
+              {(
+                t("footer.section.support.links", {
+                  returnObjects: true,
+                }) as Array<{ text: string; url: string }>
+              ).map((link, i) => (
+                <li key={i}>
+                  <a href={link.url}>{link.text}</a>
+                </li>
               ))}
             </ul>
           </div>
-          <div className="ds-l-col--2">
+          <div className={columnClasses}>
             <h4 className={linkHeaderClasses}>
               {t("footer.section.cms.title")}
             </h4>
             <ul className="usa-list usa-list--unstyled">
-              {(t("footer.section.cms.links", { returnObjects: true }) as Array<{text: string, url: string}>).map((link, i) => (
-                <li key={i}><a href={link.url}>{link.text}</a></li>
+              {(
+                t("footer.section.cms.links", {
+                  returnObjects: true,
+                }) as Array<{ text: string; url: string }>
+              ).map((link, i) => (
+                <li key={i}>
+                  <a href={link.url}>{link.text}</a>
+                </li>
               ))}
             </ul>
           </div>
-          <div className="ds-l-col--2">
+          <div className={columnClasses}>
             <h4 className={linkHeaderClasses}>
               {t("footer.section.info.title")}
             </h4>
             <ul className="usa-list usa-list--unstyled">
-              {(t("footer.section.info.links", { returnObjects: true }) as Array<{text: string, url: string}>).map((link, i) => (
-                <li key={i}><a href={link.url}>{link.text}</a></li>
+              {(
+                t("footer.section.info.links", {
+                  returnObjects: true,
+                }) as Array<{ text: string; url: string }>
+              ).map((link, i) => (
+                <li key={i}>
+                  <a href={link.url}>{link.text}</a>
+                </li>
               ))}
             </ul>
           </div>

--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -15,15 +15,21 @@
 }
 
 .title {
-  align-items: center;
   display: flex;
+  flex-direction: row;
+  align-items: center;
   flex-wrap: nowrap;
-  white-space: nowrap;
 }
 
 .logo {
   margin-right: 0.5rem;
   width: 8.875rem;
+}
+
+.textContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .logoText {
@@ -35,14 +41,13 @@
   font-style: normal;
   font-weight: var(--theme-font-weight-heading-2xl, 700);
   line-height: 130%; /* 1.95rem */
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .betaBadge {
   align-items: center;
   background: #0071bc;
-  display: inline-flex !important;
-  gap: 0.625rem;
-  justify-content: center;
   margin-left: 0.5rem;
   padding: var(--spacer-half, 0.25rem) var(--spacer-1, 0.5rem);
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,8 +8,9 @@ import { apiUrl } from "../state/api"
 import { useFrontendSettings } from "../state/FrontendSettingsProvider"
 import { CsrfInput } from "./forms/CsrfInput"
 import { getCookie } from "./getCookie"
-import styles from "./Header.module.css"
 import { slugId } from "./markdown/slug"
+
+import styles from "./Header.module.css"
 
 const AuthenticationControl = () => {
   const { t } = useTranslation()
@@ -63,6 +64,12 @@ export const Header = ({ hideLinks }: HeaderProps) => {
     settings: { user },
   } = useFrontendSettings()
   const classes = classnames("usa-header", "usa-header--basic", styles.header)
+  const badgeClasses = classnames(styles.betaBadge)
+  const textContainerClasses = classnames(
+    "ds-u-md-display--flex",
+    "ds-u-display--none",
+    styles.textContainer,
+  )
 
   return (
     <>
@@ -74,16 +81,18 @@ export const Header = ({ hideLinks }: HeaderProps) => {
             <div className={`usa-logo ${styles.title}`}>
               <a
                 href="/"
-                className="ds-u-display--flex ds-l-col--6 ds-u-align-items--center ds-u-padding-left--0"
+                className="ds-u-display--flex ds-u-flex-direction--row ds-u-padding-left--0"
                 title="Return to the homepage"
               >
                 <img src={cmsLogo} className={styles.logo} alt="CMS.gov" />
-                <em className={`${styles.logoText} usa-logo__text `}>
-                  {t("header.title")}
-                </em>
-                <Badge variation="info" className={styles.betaBadge}>
-                  {t("header.badge")}
-                </Badge>
+                <div className={textContainerClasses}>
+                  <em className={`${styles.logoText} usa-logo__text`}>
+                    {t("header.title")}
+                  </em>
+                  <Badge variation="info" className={badgeClasses}>
+                    {t("header.badge")}
+                  </Badge>
+                </div>
               </a>
             </div>
             {!hideLinks && (

--- a/frontend/src/pages/Login.module.css
+++ b/frontend/src/pages/Login.module.css
@@ -13,12 +13,7 @@
 }
 
 .card {
-  display: flex;
-  width: 31.0625rem;
   padding: var(--spacer-3, 1.5rem);
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--spacer-2, 1rem);
   background: var(--color-white-solid, #fff);
 
   & h1 {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -19,7 +19,7 @@ export const Login = () => {
     <main className={mainClasses}>
       <div className="ds-base ds-l-container">
         <div className="ds-l-row">
-          <div className="ds-l-md-col--8 ds-l-sm-col--12">
+          <div className="ds-l-lg-col--6 ds-l-md-col--8">
             <div className={styles.spacer}></div>
             <div className={styles.card}>
               <form


### PR DESCRIPTION
## responsive design: ensure login page is responsive to small screen sizes

[Jira Ticket NDH-446](https://jiraent.cms.gov/browse/NDH-446)

## Problem

Landing page looks bad on mobile. 

<details>

<summary>Click here to see the screenshot.</summary>

<img width="654" height="1025" alt="current-login-page--mobile" src="https://github.com/user-attachments/assets/ee5c35d8-4643-4f33-90bd-6418374b3796" />

</details> 

## Solution

Remove static width from login form "card" element. 

Ensure we're using appropriate responsive classes from [CMS Design System](https://design.cms.gov/foundation/layout-grid/responsive-design/?theme=core).

## Result

Screenshots from my development machine via Chrome responsive mode.

<details>

<summary>Mobile M - 375px</summary>

<img width="375" height="1377" alt="responsive-login-page--mobile" src="https://github.com/user-attachments/assets/b0dde454-5672-4527-8c39-c70fae43cf2b" />

</details> 

<details>

<summary>Tablet - 768px width</summary>

<img width="768" height="975" alt="responsive-login-page--tablet" src="https://github.com/user-attachments/assets/1dd4d161-3710-4a52-be81-06499515c829" />

</details> 


<details>

<summary>Desktop - 1440px width</summary>

<img width="1440" height="989" alt="responsive-login-page--desktop" src="https://github.com/user-attachments/assets/5b36b4c8-d57b-4d8b-ae58-db86f7c8a2ed" />

</details> 

