### PR TITLE
Use an alias to describe directory domain

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -47,6 +47,7 @@ module "dns" {
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain
   directory_alb_dns_name               = module.fhir-api.api_dot_alb_dns_name
+  directory_alb_zone_id                = module.fhir-api.api_alb_zone_id
   etl_domain                           = module.domains.etl_domain
   etl_alb_dns_name                     = module.etl.dagster_ui_alb_dns_name
 }

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -45,6 +45,7 @@ module "dns" {
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain
   directory_alb_dns_name               = module.fhir-api.api_dot_alb_dns_name
+  directory_alb_zone_id                = module.fhir-api.api_alb_zone_id
   etl_domain                           = module.domains.etl_domain
   etl_alb_dns_name                     = module.etl.dagster_ui_alb_dns_name
 }

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -14,9 +14,13 @@ resource "aws_route53_record" "directory" {
   count   = var.enable_internal_domain_for_directory ? 1 : 0
   zone_id = aws_route53_zone.internal_dns.zone_id
   name    = var.directory_domain
-  type    = "CNAME"
-  ttl     = "300"
-  records = [var.directory_alb_dns_name]
+  type    = "A"
+
+  alias {
+    name                   = var.directory_alb_dns_name
+    zone_id                = var.directory_alb_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "api" {

--- a/infrastructure/modules/dns/variables.tf
+++ b/infrastructure/modules/dns/variables.tf
@@ -2,6 +2,7 @@ variable "api_domain" {}
 variable "api_alb_dns_name" {}
 variable "directory_domain" {}
 variable "directory_alb_dns_name" {}
+variable "directory_alb_zone_id" {}
 variable "etl_domain" {}
 variable "etl_alb_dns_name" {}
 variable "enable_internal_domain_for_directory" {}

--- a/infrastructure/modules/fhir-api/outputs.tf
+++ b/infrastructure/modules/fhir-api/outputs.tf
@@ -5,3 +5,7 @@ output "api_alb_dns_name" {
 output "api_dot_alb_dns_name" {
   value = aws_alb.fhir_api_alb_redirect.dns_name
 }
+
+output "api_alb_zone_id" {
+  value = aws_lb.fhir_api_alb.zone_id
+}


### PR DESCRIPTION
## module-name: Use an alias to describe directory domain

### Jira Ticket # n/a 

## Problem

I specified the `dev.directory.internal.cms.gov` CNAME record incorrectly.

```hcl
│ Error: creating Route53 Record: operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: ed675cba-cf32-415e-a0d7-c21a68a0e802, InvalidChangeBatch: [RRSet of type CNAME with DNS name dev.directory.internal.cms.gov. is not permitted at apex in zone dev.directory.internal.cms.gov.]
│ 
│   with module.dns.aws_route53_record.directory[0],
│   on ../../modules/dns/main.tf line 13, in resource "aws_route53_record" "directory":
│   13: resource "aws_route53_record" "directory" {
│ 
```

## Solution

Specify an alias domain https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#alias-record

## Result

- `dev.directory.internal.cms.gov` domain created
- build fixed

## Test Plan

merge it, check CI
