### PR TITLE
ensure header title does not wrap at desktop size

### DIFF
--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -21,7 +21,7 @@
   flex-wrap: nowrap;
 }
 
-@media (max-width: 63.99em) {
+@media (min-width: 34em) and (max-width: 63.99em) {
   .title {
     margin-left: var(--grid-gutter-width);
   }


### PR DESCRIPTION
## responsive design: Fix header line wrapping

## Problem

New responsive design of header breaks at desktop resolution.

_before_: 

<img width="539" height="229" alt="image" src="https://github.com/user-attachments/assets/354f347e-6ff0-4788-a912-56fce90adbd3" />

## Solution

Add `whitespace: nowrap` to the text component of the header logo element.

## Result

_after_:

Desktop:

<img width="888" height="194" alt="image" src="https://github.com/user-attachments/assets/645ae935-1d07-43cd-89e8-41be6a4a2ad4" />

---

Tablet: 

<img width="682" height="204" alt="image" src="https://github.com/user-attachments/assets/28672703-1553-4f72-9f3b-2b4de97c6570" />

---

Mobile: 

<img width="360" height="236" alt="image" src="https://github.com/user-attachments/assets/ef7541f4-eeb1-484f-bb62-89199eb770c0" />

