### PR TITLE
fix: address sorting change test breakage for LocationViewSetTestCase

### DIFF
--- a/backend/npdfhir/tests/test_location.py
+++ b/backend/npdfhir/tests/test_location.py
@@ -71,7 +71,7 @@ class LocationViewSetTestCase(APITestCase):
 
     def test_list_in_order_by_address(self):
         url = reverse("fhir-location-list")
-        response = self.client.get(url,  {"_sort": 'address_full'})
+        response = self.client.get(url,  {"_sort": 'address_full,name'})
         assert_fhir_response(self, response)
 
         # Extract names


### PR DESCRIPTION
## backend tests: fix sorting expectation in LocationViewSetTestCase

## Problem

The merge of #117 into `main` caused a test to start failing.

## Solution

There's something very funny going on with how postgres is naturally sorting records which have the same complex concatenated string field.

To fix the test and move on, I added name to the sort param passed to the FHIR API in the test to ensure the expected ordering was returned.

## Result

```shell 
docker compose -f backend/docker-compose.yml -f backend/compose.test.yml run --rm django-web python manage.py test npdfhir.tests.LocationViewSetTestCase.test_list_in_order_by_address

# and 

make test
```

are green, now.

## Testing 

`make test` should run without failures and the test should run successfully in isolation.