### PR TITLE
Fixing Failing Gitleaks Action

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -233,3 +233,5 @@ e1161fe24ddffc2afaac005126d2e21666d36dcc:db/sql/inserts/sample_data.sql:generic-
 22bb4d12d16dcdda27efc8389df470af6e576c96:playwright/node_modules/@types/node/package.json:tfstate-provider-ids:110
 22bb4d12d16dcdda27efc8389df470af6e576c96:playwright/node_modules/@types/node/package.json:tfstate-provider-ids:120
 22bb4d12d16dcdda27efc8389df470af6e576c96:playwright/node_modules/@types/node/package.json:tfstate-provider-ids:125
+22bb4d12d16dcdda27efc8389df470af6e576c96:playwright/node_modules/@types/node/package.json:tfstate-provider-ids:35
+22bb4d12d16dcdda27efc8389df470af6e576c96:playwright/node_modules/@types/node/package.json:tfstate-provider-ids:75


### PR DESCRIPTION
Builds were failing due to false positives found within packages so added their fingerprints to .gitleaksignore