### PR TITLE
[NDH-397] Initial practitioner page

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -252,8 +252,8 @@ SWAGGER_SETTINGS = {"USE_SESSION_AUTH": False}
 # feature flags
 FLAGS = {
     "SEARCH_APP": [],  # can see the search app at all
-    "PROVIDER_LOOKUP": [],  # can reach the provider lookup page
-    "PROVIDER_LOOKUP_DETAILS": [],  # can reach all details in the provider lookup page
+    "PRACTITIONER_LOOKUP": [],  # can reach the provider lookup page
+    "PRACTITIONER_LOOKUP_DETAILS": [],  # can reach all details in the provider lookup page
     "ORGANIZATION_LOOKUP": [],
     "ORGANIZATION_LOOKUP_DETAILS": [],
     # static conditions can be defined in this file or through the Admin interface

--- a/backend/npdfhir/management/commands/seeduser.py
+++ b/backend/npdfhir/management/commands/seeduser.py
@@ -1,11 +1,27 @@
 from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand
+from flags.models import FlagState
 
 # from fhir.resources.R4B import organization, practitioner
 
 
 class Command(BaseCommand):
     help = "Create a developer@cms.hhs.gov in the Developers group"
+
+    def prepare_feature_flags(self):
+        FlagState.objects.get_or_create(name="SEARCH_APP", condition="in_group", value="Developers")
+        FlagState.objects.get_or_create(
+            name="PRACTITIONER_LOOKUP", condition="in_group", value="Developers"
+        )
+        FlagState.objects.get_or_create(
+            name="PRACTITIONER_LOOKUP_DETAILS", condition="in_group", value="Developers"
+        )
+        FlagState.objects.get_or_create(
+            name="ORGANIZATION_LOOKUP", condition="in_group", value="Developers"
+        )
+        FlagState.objects.get_or_create(
+            name="ORGANIZATION_LOOKUP_DETAILS", condition="in_group", value="Developers"
+        )
 
     def handle(self, *args, **options):
         user, _ = User.objects.get_or_create(username="developer@cms.hhs.gov")
@@ -16,5 +32,7 @@ class Command(BaseCommand):
 
         user.save()
         group.save()
+
+        self.prepare_feature_flags()
 
         self.stdout.write("Created developer@cms.hhs.gov account and added to Developer group")

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,6 +21,7 @@ import { Layout } from "./pages/Layout"
 import { Login } from "./pages/Login"
 import { NotFound } from "./pages/NotFound.tsx"
 import { Organization } from "./pages/Organization"
+import { Practitioner } from "./pages/Practitioner/Practitioner.tsx"
 import { Search } from "./pages/Search"
 import { FrontendSettingsProvider } from "./state/FrontendSettingsProvider"
 
@@ -45,6 +46,10 @@ createRoot(document.getElementById("root")!).render(
                     <Route
                       path="/organizations/:organizationId"
                       element={<Organization />}
+                    />
+                    <Route
+                      path="/practitioners/:practitionerId"
+                      element={<Practitioner />}
                     />
                   </Route>
                 </Route>

--- a/frontend/src/pages/Practitioner/Practitioner.test.tsx
+++ b/frontend/src/pages/Practitioner/Practitioner.test.tsx
@@ -1,0 +1,80 @@
+import { screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router"
+import { beforeEach, describe, expect, it } from "vitest"
+import { DEFAULT_PRACTITIONER } from "../../../tests/fixtures"
+import {
+  mockGlobalFetch,
+  settingsResponseWithFeature,
+  type MockResponse,
+} from "../../../tests/mockGlobalFetch"
+import { render } from "../../../tests/render"
+import type { Practitioner as FHIRPractitioner } from "../../state/requests/practitioners"
+import { Practitioner } from "./Practitioner"
+
+const orgApiResponse: MockResponse = [
+  "^/fhir/Practitioner/.*",
+  DEFAULT_PRACTITIONER,
+]
+
+const EXPECTED_NPI =
+  (DEFAULT_PRACTITIONER as FHIRPractitioner)["identifier"]?.[0]?.value ||
+  "EXPECTED_NPI IS UNSET FIXME"
+const EXPECTED_NAME =
+  (DEFAULT_PRACTITIONER as FHIRPractitioner)["name"]?.[0]?.text ||
+  "EXPECTED_NAME IS UNSET FIXME"
+
+const RoutedPractitioner = ({ path }: { path: string }) => {
+  return (
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/practitioners/:practitionerId"
+          element={<Practitioner />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe("Practitioner", () => {
+  describe("without PRACTITIONER_LOOKUP_DETAILS feature flag", () => {
+    beforeEach(() => {
+      mockGlobalFetch([
+        settingsResponseWithFeature({ PRACTITIONER_LOOKUP_DETAILS: false }),
+        orgApiResponse,
+      ])
+    })
+
+    it("does not render content when feature flag is unset", async () => {
+      render(<RoutedPractitioner path="/practitioners/12345" />)
+
+      // ensure loading has finished
+      await screen.findByText(EXPECTED_NAME)
+
+      expect(screen.queryByText(`NPI: ${EXPECTED_NPI}`)).toBeInTheDocument()
+      expect(
+        screen.queryByText("About", { selector: "section h2" }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("with PRACTITIONER_LOOKUP_DETAILS feature flag", () => {
+    beforeEach(() => {
+      // update /api/frontend_settings mocked response
+      mockGlobalFetch([
+        settingsResponseWithFeature({ PRACTITIONER_LOOKUP_DETAILS: true }),
+        orgApiResponse,
+      ])
+    })
+
+    it("shows detailed content", async () => {
+      render(<RoutedPractitioner path="/practitioners/12345" />)
+
+      await screen.findByText(EXPECTED_NAME)
+      await screen.findByText("About", { selector: "section h2" })
+      await screen.findByText("Contact information", { selector: "section h2" })
+      await screen.findByText("Identifiers", { selector: "section h2" })
+      await screen.findByText("Taxonomy", { selector: "section h2" })
+    })
+  })
+})

--- a/frontend/src/pages/Practitioner/Practitioner.tsx
+++ b/frontend/src/pages/Practitioner/Practitioner.tsx
@@ -1,0 +1,100 @@
+import { Alert } from "@cmsgov/design-system"
+import classNames from "classnames"
+import { useParams } from "react-router"
+import { FeatureFlag } from "../../components/FeatureFlag"
+import { LoadingIndicator } from "../../components/LoadingIndicator"
+import { organizationNpiSelector } from "../../state/requests/organizations"
+import {
+  practitionerAddressOneline,
+  practitionerNameSelector,
+  usePractitionerAPI,
+} from "../../state/requests/practitioners"
+import layout from "../Layout.module.css"
+
+export const Practitioner = () => {
+  const { practitionerId } = useParams()
+  const { data, error, isLoading } = usePractitionerAPI(practitionerId)
+
+  if (isLoading) {
+    return <LoadingIndicator />
+  }
+
+  if (typeof data === "undefined" || error) {
+    return <p>API Error: {JSON.stringify(error)}</p>
+  }
+
+  const contentClass = classNames(layout.content, "ds-l-container")
+  const bannerClass = classNames(layout.banner)
+
+  return (
+    <>
+      <section className={bannerClass}>
+        <div className="ds-l-container">
+          <div className="ds-l-row">
+            <div className="ds-l-col--12">
+              <div className={layout.leader}>
+                <h1 role="heading" aria-level={1} className={layout.title}>
+                  {practitionerNameSelector(data)}
+                </h1>
+                <span
+                  data-testid="practitioner-npi"
+                  className={layout.subtitle}
+                >
+                  NPI: {organizationNpiSelector(data)}
+                </span>
+                {data.address && (
+                  <span
+                    data-testid="practitioner-npi"
+                    className={layout.subtitle}
+                  >
+                    {practitionerAddressOneline(data)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <main className={contentClass}>
+        <FeatureFlag inverse name="PRACTITIONER_LOOKUP_DETAILS">
+          <Alert variation="warn" heading="Content not available">
+            This content is not currently available.
+          </Alert>
+        </FeatureFlag>
+
+        <FeatureFlag name="PRACTITIONER_LOOKUP_DETAILS">
+          <Alert heading="Are you the practitioner listed?">
+            Learn how to <a href="#">update your information</a>.
+          </Alert>
+
+          <section className={layout.section}>
+            <h2>About</h2>
+            <p>[demographic information]</p>
+          </section>
+
+          <section className={layout.section}>
+            <h2>Contact information</h2>
+            <p>[contact information]</p>
+          </section>
+
+          <section className={layout.section}>
+            <h2>Identifiers</h2>
+            <p>[identifier information]</p>
+          </section>
+
+          <section className={layout.section}>
+            <h2>Taxonomy</h2>
+            <p>[taxonomy information]</p>
+          </section>
+
+          <section className={layout.section}>
+            <h2>Organization(s)</h2>
+            <p>[endpoint information]</p>
+          </section>
+        </FeatureFlag>
+
+        <div className="ds-u-margin-top--7"></div>
+      </main>
+    </>
+  )
+}

--- a/frontend/src/pages/Practitioner/index.ts
+++ b/frontend/src/pages/Practitioner/index.ts
@@ -1,0 +1,1 @@
+export { Practitioner } from "./Practitioner"

--- a/frontend/src/state/requests/organizations.ts
+++ b/frontend/src/state/requests/organizations.ts
@@ -43,7 +43,9 @@ export const useOrganizationAPI = (organizationId: string | undefined) => {
 // Selectors unpack the API responses
 ////
 
-export const organizationNpiSelector = (org?: Organization) => {
+export const organizationNpiSelector = (
+  org?: Pick<Organization, "identifier">,
+) => {
   if (!org) return ""
 
   if (!org.identifier?.length) {
@@ -51,7 +53,9 @@ export const organizationNpiSelector = (org?: Organization) => {
   }
 
   const npiIdentifier = org.identifier.find(
-    (ident) => ident.system === "http://terminology.hl7.org/NamingSystem/npi",
+    (ident) =>
+      ident.system === "http://terminology.hl7.org/NamingSystem/npi" ||
+      ident.system === "http://hl7.org/fhir/sid/us-npi",
   )
 
   return npiIdentifier?.value || "n/a"

--- a/frontend/src/state/requests/practitioners.ts
+++ b/frontend/src/state/requests/practitioners.ts
@@ -30,7 +30,6 @@ export const usePractitionerAPI = (practitionerId: string | undefined) => {
   return useQuery<Practitioner>({
     queryKey: ["practitioner", practitionerId],
     queryFn: () => {
-      console.log("fetch practitioner?", practitionerId)
       if (!practitionerId) {
         return Promise.reject("no practitionerId was provided")
       }
@@ -47,9 +46,18 @@ export const usePractitionerAPI = (practitionerId: string | undefined) => {
 export const practitionerNameSelector = (
   record: Practitioner,
 ): string | null => {
-  if (!record.name || record.name?.length === 0) return null
+  if (!record.name || record.name?.length === 0) return "No name available"
 
   const name: HumanName = record.name[0] as unknown as HumanName
 
   return name.text || ""
+}
+
+export const practitionerAddressOneline = (
+  record: Practitioner,
+): string | null => {
+  if (!record.address || record.address.length === 0)
+    return "No address available"
+
+  return ""
 }

--- a/frontend/tests/fixtures/fhir_practitioner.json
+++ b/frontend/tests/fixtures/fhir_practitioner.json
@@ -1,0 +1,54 @@
+{
+  "resourceType": "Practitioner",
+  "id": "c3a56586-40a8-4fef-9394-2dd0c0ba0b60",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+    ]
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "PRN",
+            "display": "Provider number"
+          }
+        ]
+      },
+      "system": "http://terminology.hl7.org/NamingSystem/npi",
+      "value": "1720081672",
+      "period": { "start": "2005-05-24T00:00:00" }
+    }
+  ],
+  "name": [
+    {
+      "use": "usual",
+      "text": "DR. KIRK AADALEN",
+      "family": "AADALEN",
+      "given": ["KIRK", null],
+      "prefix": ["DR."],
+      "suffix": [null],
+      "period": { "start": "1900-01-01T00:00:00" }
+    }
+  ],
+  "address": [
+    {
+      "line": ["8170 33rd Ave S Stop 21110Q"],
+      "city": "Bloomington",
+      "state": "MN",
+      "postalCode": "55425",
+      "country": "US"
+    },
+    {
+      "line": ["8100 Northland Dr"],
+      "city": "Bloomington",
+      "state": "MN",
+      "postalCode": "55431",
+      "country": "US"
+    }
+  ],
+  "qualification": []
+}

--- a/frontend/tests/fixtures/index.ts
+++ b/frontend/tests/fixtures/index.ts
@@ -1,5 +1,7 @@
 import type { Organization } from "../../src/@types/fhir/Organization"
+import type { Practitioner } from "../../src/@types/fhir/Practitioner"
 import fhirOrganization from "./fhir_organization.json"
+import fhirPractitioner from "./fhir_practitioner.json"
 
 export const DEFAULT_FRONTEND_SETTINGS: FrontendSettings = {
   require_authentication: false,
@@ -8,3 +10,4 @@ export const DEFAULT_FRONTEND_SETTINGS: FrontendSettings = {
 }
 
 export const DEFAULT_ORGANIZATION: Organization = fhirOrganization
+export const DEFAULT_PRACTITIONER: Practitioner = fhirPractitioner

--- a/frontend/tests/mockGlobalFetch.ts
+++ b/frontend/tests/mockGlobalFetch.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest"
 import type { Organization } from "../src/@types/fhir/Organization"
+import type { Practitioner } from "../src/@types/fhir/Practitioner"
 
 export const DEFAULT_FRONTEND_SETTINGS: FrontendSettings = {
   require_authentication: false,
@@ -26,7 +27,7 @@ export const settingsResponseWithFeature = (
 
 type UrlMatch = string
 // new API response types should be added as a union to ApiResponseType
-type ApiResponseType = FrontendSettings | Organization
+type ApiResponseType = FrontendSettings | Organization | Practitioner
 
 export type MockResponse = [UrlMatch, ApiResponseType]
 

--- a/playwright/tests/practitioners/practitioners.spec.ts
+++ b/playwright/tests/practitioners/practitioners.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test"
+
+import fhir_practitioner from "../../../frontend/tests/fixtures/fhir_practitioner.json"
+
+test.describe("Practitioners", () => {
+  test.use({ storageState: "tests/.auth/user.json" })
+
+  test("visit a practitioner page", async ({ page }) => {
+    // mock the API using the existing test fixture from frontend/
+    await page.route(
+      "*/**/fhir/Practitioner/73768136-3d4e-453c-a761-1a13962a42eb/",
+      async (route) => {
+        const json = fhir_practitioner
+        await route.fulfill({ json })
+      },
+    )
+
+    await page.goto("/practitioners/73768136-3d4e-453c-a761-1a13962a42eb")
+
+    await expect(page).toHaveURL(
+      "/practitioners/73768136-3d4e-453c-a761-1a13962a42eb",
+    )
+
+    await expect(page.locator("h1[role='heading']")).toContainText(
+      "DR. KIRK AADALEN",
+    )
+  })
+})


### PR DESCRIPTION
## frontend details: Practitioner landing page stub

[Jira Ticket NDH-397](https://jiraent.cms.gov/browse/NDH-397)

Initial release of a Practitioner details page to match the basic Organization details page from #198.

## Other changes

This work builds on the automated-typing in #239 to clarify the expected output of our FHIR API, so it has a few cases where I updated Organization components to keep up.

I changed the `PROVIDER_LOOKUP` and `PROVIDER_LOOKUP_DETAILS` feature flags to use `PRACTITIONER` instead of `PROVIDER`.

## Screenshot

<img width="1024" height="1516" alt="localhost_8000_practitioners_73768136-3d4e-453c-a761-1a13962a42eb (1)" src="https://github.com/user-attachments/assets/d8024540-c4da-4ce3-9ba3-01fcf04ea278" />

## Test Plan

This PR includes new component-level unit tests covering access with and without feature flags set and a new end-to-end test visiting the page with the project-default account and feature flag settings: 

- username: `developer@cms.hhs.gov`
- password: `password123`
- enabled feature flags: `SEARCH_APP`, `PRACTITIONER_LOOKUP_DETAILS`

The same user account is available in your dev environment after running `make migrate`.