### PR TITLE
[NDH-550] fix: Organization component test should wait for FeatureFlag to render

### DIFF
--- a/frontend/src/pages/Organization/Organization.test.tsx
+++ b/frontend/src/pages/Organization/Organization.test.tsx
@@ -40,8 +40,8 @@ describe("Organization", () => {
     it("does not render content when feature flag is unset", async () => {
       render(<RoutedOrganization path="/organizations/12345" />)
 
-      // ensure loading has finished
-      await screen.findByText("Provider group")
+      // ensure FeatureFlag components have finished loading
+      await screen.findByText("Content not available")
 
       expect(screen.queryByText("About", { selector: "section h2" })).toBeNull()
     })
@@ -59,7 +59,9 @@ describe("Organization", () => {
     it("shows detailed content", async () => {
       render(<RoutedOrganization path="/organizations/12345" />)
 
-      await screen.findByText("Provider group")
+      // ensure FeatureFlag components have finished loading
+      await screen.findByText("Are you the practitioner listed?")
+
       expect(
         screen.queryByText("About", { selector: "section h2" }),
       ).toBeInTheDocument()


### PR DESCRIPTION
[Jira Ticket NDH-550](https://jiraent.cms.gov/browse/NDH-550)

## Problem

We have a flaky test! 

The original version of `frontend/src/pages/Organization/Organization.test.tsx:60-67` looked like this:

```tsx
render(<RoutedOrganization path="/organizations/12345" />)

// ensure loading has finished
await screen.findByText("Provider group") 

expect(
  screen.queryByText("About", { selector: "section h2" }),
).toBeInTheDocument() /// <------ error happening here
```

This logic uses `await screen.findBy`, [which includes an implicit wait](https://testing-library.com/docs/dom-testing-library/api-async#findby-queries) for the appearance of "Provider group" in the top section of the Organization component and relied on the success of that call to indicate that the (mocked) Organization API call (`/fhir/Organization/{id}`) had finished and the page was rendered.

The problem is, the content being tested was wrapped in a `<FeatureFlag name="...">` component, which is dependent on a different (mocked) frontend settings API call (`/api/frontend_settings`).

If those API call promises resolve in `/api/frontend_settings` then `/fhir/Organization/{}` order, the test passes. If they resolve the other way around, the test fails. 

Most of the time, the test passes.

👃  smells like a race condition! 🏃

## Solution

I switched the tests to use content within the FeatureFlag component as a guard, which will only allow the test code to proceed when both API calls have resolved.

`frontend/src/pages/Organization/Organization.test.tsx:60-67`:

```tsx
render(<RoutedOrganization path="/organizations/12345" />)

// ensure FeatureFlag components have finished loading
await screen.findByText("Are you the practitioner listed?") //// <--- updated guard condition

expect(
  screen.queryByText("About", { selector: "section h2" }),
).toBeInTheDocument()
```

## Result

No more race condition / race condition doesn't matter. Test unflaked.

## Testing locally

I used this command in the `frontend/` directory on host to repeatedly run the test file until it failed, since most of the time it succeeds:

```sh
while npm test src/pages/Organization/Organization.test.tsx; do :; done
```

If you checkout main and run this same command, it will eventually fail.

On my machine, running the tests in a `docker compose run --rm web` container, it failed after 6 tries.