### PR TITLE
Update internal route53 configuration

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -43,6 +43,7 @@ module "dns" {
   source = "../../modules/dns"
 
   enable_internal_domain_for_directory = true
+  namespace_domain                     = module.domains.namespace_domain
   api_domain                           = module.domains.api_domain
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain

--- a/infrastructure/envs/prod-test/main.tf
+++ b/infrastructure/envs/prod-test/main.tf
@@ -41,6 +41,7 @@ module "dns" {
   source = "../../modules/dns"
 
   enable_internal_domain_for_directory = false
+  namespace_domain                     = module.domains.namespace_domain
   api_domain                           = module.domains.api_domain
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -41,6 +41,7 @@ module "dns" {
   source = "../../modules/dns"
 
   enable_internal_domain_for_directory = false
+  namespace_domain                     = module.domains.namespace_domain
   api_domain                           = module.domains.api_domain
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain

--- a/infrastructure/envs/test/main.tf
+++ b/infrastructure/envs/test/main.tf
@@ -41,6 +41,7 @@ module "dns" {
   source = "../../modules/dns"
 
   enable_internal_domain_for_directory = true
+  namespace_domain                     = module.domains.namespace_domain
   api_domain                           = module.domains.api_domain
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name
   directory_domain                     = module.domains.directory_domain

--- a/infrastructure/modules/dns/main.tf
+++ b/infrastructure/modules/dns/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "internal_dns" {
-  name = var.directory_domain
+  name = var.namespace_domain
 }
 
 resource "aws_route53_record" "ns" {
@@ -8,7 +8,7 @@ resource "aws_route53_record" "ns" {
   # created record as a separate entity from the zone
   allow_overwrite = true
   zone_id = aws_route53_zone.internal_dns.zone_id
-  name    = var.directory_domain
+  name    = var.namespace_domain
   type    = "NS"
   ttl     = 172800
   records = aws_route53_zone.internal_dns.name_servers

--- a/infrastructure/modules/dns/variables.tf
+++ b/infrastructure/modules/dns/variables.tf
@@ -5,4 +5,5 @@ variable "directory_alb_dns_name" {}
 variable "directory_alb_zone_id" {}
 variable "etl_domain" {}
 variable "etl_alb_dns_name" {}
+variable "namespace_domain" {}
 variable "enable_internal_domain_for_directory" {}

--- a/infrastructure/modules/domains/main.tf
+++ b/infrastructure/modules/domains/main.tf
@@ -4,24 +4,30 @@ locals {
       etl       = "etl.dev.cnpd.internal.cms.gov"
       api       = "api.dev.cnpd.internal.cms.gov"
       directory = "dev.cnpd.internal.cms.gov"
+      namespace = "dev.cnpd.internal.cms.gov"
     }
     test = {
       etl       = "etl.test.cnpd.internal.cms.gov"
       api       = "api.test.cnpd.internal.cms.gov"
       directory = "test.cnpd.internal.cms.gov"
+      namespace = "test.cnpd.internal.cms.gov"
     }
     prod-test = {
       etl       = "etl.prod-test.cnpd.internal.cms.gov"
       api       = "api.prod-test.cnpd.internal.cms.gov"
       directory = "prod-test.cnpd.internal.cms.gov"
+      namespace = "prod-test.cnpd.internal.cms.gov"
     }
     prod = {
       etl       = "etl.cnpd.internal.cms.gov"
       api       = "api.directory.cms.gov" # public route
       directory = "directory.cms.gov"     # public route
+      namespace = "cnpd.internal.cms.gov"
     }
   }
+
   api_domain       = local.domains[var.tier]["api"]
   directory_domain = local.domains[var.tier]["directory"]
   etl_domain       = local.domains[var.tier]["etl"]
+  namespace_domain = local.domains[var.tier]["namespace"]
 }

--- a/infrastructure/modules/domains/outputs.tf
+++ b/infrastructure/modules/domains/outputs.tf
@@ -7,3 +7,6 @@ output "directory_domain" {
 output "etl_domain" {
   value = local.etl_domain
 }
+output "namespace_domain" {
+  value = local.namespace_domain
+}


### PR DESCRIPTION
## module-name: Update configuration of internal routes in route53

### Jira Ticket #

## Problem

I've been using the directory domain as the internal domain namespace, which works fine at lower envs but in prod, where the directory domain is public, the dns zone and namespace domain is `directory.cms.gov` rather than `cnpd.internal.cms.gov`

```hcl
 # module.dns.aws_route53_record.etl will be created
  + resource "aws_route53_record" "etl" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "etl.cnpd.internal.cms.gov"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = (known after apply)
    }

  # module.dns.aws_route53_record.ns will be created
  + resource "aws_route53_record" "ns" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "directory.cms.gov"
      + records         = (known after apply)
      + ttl             = 172800
      + type            = "NS"
      + zone_id         = (known after apply)
    }

  # module.dns.aws_route53_zone.internal_dns will be created
  + resource "aws_route53_zone" "internal_dns" {
      + arn                 = (known after apply)
      + comment             = "Managed by Terraform"
      + force_destroy       = false
      + id                  = (known after apply)
      + name                = "directory.cms.gov"
      + name_servers        = (known after apply)
      + primary_name_server = (known after apply)
      + tags_all            = (known after apply)
      + zone_id             = (known after apply)
    }
```

## Solution

Updated the domains module to export a "namespace" domain, updated dns module to read the namespace domain parameter and now my plan looks like:

```hcl
  # module.dns.aws_route53_record.etl will be created
  + resource "aws_route53_record" "etl" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "etl.cnpd.internal.cms.gov"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = (known after apply)
    }

  # module.dns.aws_route53_record.ns will be created
  + resource "aws_route53_record" "ns" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "cnpd.internal.cms.gov"
      + records         = (known after apply)
      + ttl             = 172800
      + type            = "NS"
      + zone_id         = (known after apply)
    }

  # module.dns.aws_route53_zone.internal_dns will be created
  + resource "aws_route53_zone" "internal_dns" {
      + arn                 = (known after apply)
      + comment             = "Managed by Terraform"
      + force_destroy       = false
      + id                  = (known after apply)
      + name                = "cnpd.internal.cms.gov"
      + name_servers        = (known after apply)
      + primary_name_server = (known after apply)
      + tags_all            = (known after apply)
      + zone_id             = (known after apply)
    }
```

## Test Plan

- Nothing should change in lower envs
- The next prod deploy will update route53
