### PR TITLE
Prod-Test API/directory domains

### DIFF
--- a/infrastructure/envs/prod-test/main.tf
+++ b/infrastructure/envs/prod-test/main.tf
@@ -40,7 +40,7 @@ module "domains" {
 module "dns" {
   source = "../../modules/dns"
 
-  enable_internal_domain_for_directory = false
+  enable_internal_domain_for_directory = true
   namespace_domain                     = module.domains.namespace_domain
   api_domain                           = module.domains.api_domain
   api_alb_dns_name                     = module.fhir-api.api_alb_dns_name


### PR DESCRIPTION
## module-name: Prod-Test API/directory domains

### Jira Ticket #

## Problem 

We want to be able to resolve the API and directory applications in prod-test on the internal network

## Solution

Update DNS module to include api.prod-test.cnpd.internal.cms.gov and prod-test.cnpd.internal.cms.gov in the prod-test hosted DNS zone

## Result

```hcl

Terraform will perform the following actions:

  # module.dns.aws_route53_record.api[0] will be created
  + resource "aws_route53_record" "api" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "api.prod-test.cnpd.internal.cms.gov"
      + records         = [
          + "internal-npd-east-prod-test-fhir-api-alb-1490303286.us-east-1.elb.amazonaws.com",
        ]
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "Z05560101YIRBLDFVDRKK"
    }

  # module.dns.aws_route53_record.directory[0] will be created
  + resource "aws_route53_record" "directory" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "prod-test.cnpd.internal.cms.gov"
      + type            = "A"
      + zone_id         = "Z05560101YIRBLDFVDRKK"

      + alias {
          + evaluate_target_health = true
          + name                   = "internal-npd-east-prod-test-fhir-redirect-1955810963.us-east-1.elb.amazonaws.com"
          + zone_id                = "Z35SXDOTRQ7X7K"
        }
    }
```

## Test Plan

```bash
terraform -chdir=envs/prod-test plan -target=module.dns
```