### PR TITLE
[NDH-566] Change trigger for backend tests

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -6,9 +6,6 @@ permissions:
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   lint:


### PR DESCRIPTION
## Change trigger for backend tests

### Jira Ticket #NDH-566

## Problem

The status checks for backend tests on PRs are not properly reporting status

## Solution

I filed an [issue with the upstream publishing github action](https://github.com/EnricoMi/publish-unit-test-result-action/issues/707) describing the issue. The current hypothesis for why the status checks are not being reported for the action is that we have a trigger for both on push as well as on pull request which makes the two triggers override each other when `main` is the branch that is being merged into `release.`

"Maybe the fact that you are pushing to master while having a pull request from master to release is the special situation where the two checks do not make it."


## Result

Delete the on push trigger so that we only use this for pr checks at least for now. 
