### PR TITLE
fixing dumb db var name bug

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -150,7 +150,7 @@ module "fhir-api" {
     db_instance_master_user_secret_arn = module.api-db.db_instance_master_user_secret_arn
     db_instance_address                = module.api-db.db_instance_address
     db_instance_port                   = module.api-db.db_instance_port
-    db_instance_name                   = module.api-db.db_instance_name
+    db_instance_name                   = "npd_halloween_sjp"
   }
   networking = {
     private_subnet_ids    = module.networking.private_subnet_ids
@@ -178,7 +178,7 @@ module "etl" {
     db_instance_master_user_secret_arn = module.etl-db.db_instance_master_user_secret_arn
     db_instance_address                = module.etl-db.db_instance_address
     db_instance_port                   = module.etl-db.db_instance_port
-    db_instance_name                   = "npd_halloween_sjp"
+    db_instance_name                   = module.etl-db.db_instance_name
   }
   networking = {
     private_subnet_ids        = module.networking.private_subnet_ids


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: fixing dumb db var name bug
### Jira Ticket #

## Problem

I'm an idiot and I changed the wrong var

## Solution

Now I'm changing the right var
