### PR TITLE
Wbprice/remove ecs gha service

### DIFF
--- a/infrastructure/envs/dev/main.tf
+++ b/infrastructure/envs/dev/main.tf
@@ -237,5 +237,4 @@ module "github-actions" {
   subnet_ids                  = module.networking.private_subnet_ids
   ecs_cluster_id              = module.ecs.cluster_id
   github_runner_image         = var.github_runner_image
-  enable_containerized_runner = true
 }

--- a/infrastructure/envs/prod/main.tf
+++ b/infrastructure/envs/prod/main.tf
@@ -238,5 +238,4 @@ module "github-actions" {
   subnet_ids                  = module.networking.private_subnet_ids
   ecs_cluster_id              = module.ecs.cluster_id
   github_runner_image         = var.github_runner_image
-  enable_containerized_runner = true
 }


### PR DESCRIPTION
Turns off GHA containerized runners, which aren't working anyway.