### PR TITLE
update weekly refresh token using date modulo'd by 7 rather than mill…

### DIFF
--- a/infrastructure/modules/github-actions-runner/main.tf
+++ b/infrastructure/modules/github-actions-runner/main.tf
@@ -78,7 +78,7 @@ data "template_file" "bootstrap_runner" {
     RUNNER_DIR     = "/opt/actions-runner"
     GITHUB_URL     = "https://github.com/CMS-Enterprise/NPD"
     TIER           = var.tier
-    WEEKLY_REFRESH = floor(tonumber(formatdate("X", timestamp())) / 604800)
+    WEEKLY_REFRESH = floor(tonumber(formatdate("DD", timestamp()) / 7))
   }
 }
 


### PR DESCRIPTION
Update weekly refresh token to use days rather than milliseconds (Terraform doesn't support this but ChatGPT sure thinks it does). 