### PR TITLE
Update trust policy to read from npd-ops rather than NPD

### DIFF
--- a/infrastructure/modules/github-actions-runner/main.tf
+++ b/infrastructure/modules/github-actions-runner/main.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role" "github_runner_resource_creation_role" {
           "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
         }
         StringLike = {
-          "token.actions.githubusercontent.com:sub" = "repo:CMS-Enterprise/NPD:*"
+          "token.actions.githubusercontent.com:sub" = "repo:CMS-Enterprise/npd-ops:*"
         }
       }
       Principal = {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Update GHA role trust policy to expect roles to be assumed in npd ops rather than npd

### Jira Ticket # NDH-545

## Problem

We want to change the name of the npd repo to npd-ops to better describe what that repo is for

## Solution

Update the trust policy for the github runner

## Result

This needs to run first (to update the policy), then the repo CMS-Enterprise/npd needs to be renamed to CMS-Enteprise/npd-ops. As the admin for CMS-Enterprise/npd-ops, I can change this myself

## Test Plan

Merge it
