### PR TITLE
Add experimental FastAPI FHIR parity server

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -31,3 +31,58 @@ clean:
 	$(MAKE) clean-frontend
 	@echo "Cleanup done."
 
+.PHONY: fastapi-run
+fastapi-run:
+	@uvicorn fastapi_app.main:app --host 0.0.0.0 --port 8001 --reload
+
+.PHONY: fastapi-test
+fastapi-test:
+	@python -m unittest discover -s tests_fastapi -p 'test_*.py'
+
+.PHONY: api-parity-practitioner
+api-parity-practitioner:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/practitioner.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-practitioner-role
+api-parity-practitioner-role:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/practitioner_role.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-organization-affiliation
+api-parity-organization-affiliation:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/organization_affiliation.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-all
+api-parity-all:
+	@python -m tools.api_parity.suite \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-organization
+api-parity-organization:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/organization.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-location
+api-parity-location:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/location.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001
+
+.PHONY: api-parity-endpoint
+api-parity-endpoint:
+	@python -m tools.api_parity.runner \
+		--corpus tools/api_parity/corpus/endpoint.yaml \
+		--django-base-url http://localhost:8000 \
+		--fastapi-base-url http://localhost:8001

--- a/backend/fastapi_app/__init__.py
+++ b/backend/fastapi_app/__init__.py
@@ -1,0 +1,2 @@
+"""FastAPI replacement application package."""
+

--- a/backend/fastapi_app/_django.py
+++ b/backend/fastapi_app/_django.py
@@ -1,0 +1,44 @@
+"""Helpers for bootstrapping Django inside the FastAPI process."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import threading
+
+_SETUP_LOCK = threading.Lock()
+_SETUP_COMPLETE = False
+
+
+def ensure_django() -> None:
+    """Initialize Django exactly once for ORM/filter/serializer reuse."""
+    global _SETUP_COMPLETE
+
+    if _SETUP_COMPLETE:
+        return
+
+    with _SETUP_LOCK:
+        if _SETUP_COMPLETE:
+            return
+
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+
+        import django
+
+        django.setup()
+        _SETUP_COMPLETE = True
+
+
+@dataclass(frozen=True)
+class DjangoRequestAdapter:
+    """Minimal adapter for serializers that expect Django request helpers."""
+
+    base_url: str
+
+    def build_absolute_uri(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+
+        normalized_base = self.base_url.rstrip("/")
+        normalized_path = path if path.startswith("/") else f"/{path}"
+        return f"{normalized_base}{normalized_path}"

--- a/backend/fastapi_app/config.py
+++ b/backend/fastapi_app/config.py
@@ -1,0 +1,18 @@
+"""Runtime settings for the experimental FastAPI server."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    app_name: str = "NPD FastAPI Experiment"
+    app_version: str = "0.1.0"
+    default_page_size: int = int(os.getenv("FASTAPI_DEFAULT_PAGE_SIZE", "10"))
+    max_page_size: int = int(os.getenv("FASTAPI_MAX_PAGE_SIZE", "1000"))
+
+
+settings = Settings()
+

--- a/backend/fastapi_app/endpoint_service.py
+++ b/backend/fastapi_app/endpoint_service.py
@@ -1,0 +1,123 @@
+"""Endpoint query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import ensure_django
+
+
+@dataclass(frozen=True)
+class EndpointListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from django.db.models import F
+
+    from npdfhir.models import EndpointInstance
+
+    return (
+        EndpointInstance.objects.all()
+        .prefetch_related(
+            "endpoint_connection_type",
+            "environment_type",
+            "endpointinstancetopayload_set",
+            "endpointinstancetopayload_set__payload_type",
+            "endpointinstancetopayload_set__mime_type",
+            "endpointinstancetootherid_set",
+        )
+        .annotate(ehr_vendor_name=F("ehr_vendor__name"))
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.endpoint_filter_set import EndpointFilterSet
+
+    filterset = EndpointFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "name": "name",
+        "address": "address",
+        "ehr_vendor_name": "ehr_vendor_name",
+    }
+
+    if not sort_param:
+        return queryset.order_by("name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["name"]
+
+    return queryset.order_by(*fields)
+
+
+def list_endpoint_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+) -> EndpointListResult:
+    ensure_django()
+
+    from npdfhir.serializers import EndpointSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = EndpointSerializer(rows, many=True).data
+
+    return EndpointListResult(resources=list(resources), total_count=total_count)
+
+
+def get_endpoint_resource(endpoint_id: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import EndpointSerializer
+
+    queryset = _get_base_queryset()
+    endpoint = queryset.filter(id=endpoint_id).first()
+    if endpoint is None:
+        return None
+
+    return EndpointSerializer(endpoint).data

--- a/backend/fastapi_app/location_service.py
+++ b/backend/fastapi_app/location_service.py
@@ -1,0 +1,143 @@
+"""Location query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import DjangoRequestAdapter, ensure_django
+
+
+@dataclass(frozen=True)
+class LocationListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from django.db.models import F, Prefetch
+
+    from npdfhir.models import Location, OrganizationToAddress
+
+    return (
+        Location.objects.all()
+        .select_related(
+            "organization",
+            "address",
+            "address__address_us",
+            "address__address_us__state_code",
+        )
+        .prefetch_related(
+            Prefetch(
+                "organization__organizationtoaddress_set",
+                queryset=OrganizationToAddress.objects.select_related(
+                    "address_use", "address__address_us", "address__address_us__state_code"
+                ),
+            ),
+            "locationtoendpointinstance_set",
+        )
+        .annotate(
+            organization_name=F("organization__organizationtoname__name"),
+        )
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.location_filter_set import LocationFilterSet
+
+    filterset = LocationFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "name": "name",
+        "organization_name": "organization_name",
+    }
+
+    if not sort_param:
+        return queryset.order_by("name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["name"]
+
+    return queryset.order_by(*fields)
+
+
+def _serializer_context(base_url: str) -> dict[str, DjangoRequestAdapter]:
+    return {"request": DjangoRequestAdapter(base_url=base_url)}
+
+
+def list_location_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+    base_url: str,
+) -> LocationListResult:
+    ensure_django()
+
+    from npdfhir.serializers import LocationSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = LocationSerializer(
+        rows,
+        many=True,
+        context=_serializer_context(base_url),
+    ).data
+
+    return LocationListResult(resources=list(resources), total_count=total_count)
+
+
+def get_location_resource(location_id: str, *, base_url: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import LocationSerializer
+
+    queryset = _get_base_queryset()
+    location = queryset.filter(id=location_id).first()
+    if location is None:
+        return None
+
+    return LocationSerializer(
+        location,
+        context=_serializer_context(base_url),
+    ).data

--- a/backend/fastapi_app/main.py
+++ b/backend/fastapi_app/main.py
@@ -1,0 +1,508 @@
+"""Experimental FastAPI server for side-by-side FHIR parity work."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import FastAPI, Request
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import HTMLResponse, PlainTextResponse
+
+from .config import settings
+from .endpoint_service import get_endpoint_resource, list_endpoint_resources
+from .location_service import get_location_resource, list_location_resources
+from .organization_affiliation_service import (
+    get_organization_affiliation_resource,
+    list_organization_affiliation_resources,
+)
+from .organization_service import get_organization_resource, list_organization_resources
+from .pagination import build_bundle_envelope, get_page_window
+from .practitioner_service import get_practitioner_resource, list_practitioner_resources
+from .practitioner_role_service import (
+    get_practitioner_role_resource,
+    list_practitioner_role_resources,
+)
+from .responses import (
+    FHIRJSONResponse,
+    malformed_id_not_found,
+    missing_uuid_not_found,
+    openapi_json_response,
+)
+
+app = FastAPI(
+    title="National Provider Directory API",
+    description="Experimental FastAPI implementation for Django parity testing.",
+    version=settings.app_version,
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+def _resource_catalog(request: Request) -> dict[str, str]:
+    return {
+        "Endpoint": str(request.url_for("fhir-endpoint-list")),
+        "Location": str(request.url_for("fhir-location-list")),
+        "Organization": str(request.url_for("fhir-organization-list")),
+        "Practitioner": str(request.url_for("fhir-practitioner-list")),
+        "PractitionerRole": str(request.url_for("fhir-practitionerrole-list")),
+    }
+
+
+def _capability_statement(request: Request) -> dict:
+    base_url = str(request.base_url).rstrip("/")
+    return {
+        "resourceType": "CapabilityStatement",
+        "url": f"{base_url}/fhir/metadata/",
+        "version": settings.app_version,
+        "name": "FHIRCapabilityStatement",
+        "title": "National Provider Directory API - FHIR Capability Statement",
+        "status": "active",
+        "date": datetime.now(timezone.utc).isoformat(),
+        "publisher": "CMS",
+        "description": "Experimental FastAPI CapabilityStatement used for parity development.",
+        "kind": "instance",
+        "fhirVersion": "4.0.1",
+        "format": ["fhir+json"],
+        "rest": [
+            {
+                "mode": "server",
+                "documentation": "Experimental FastAPI FHIR endpoints for parity testing.",
+                "resource": [
+                    {
+                        "type": "Endpoint",
+                        "interaction": [{"code": "read"}, {"code": "search-type"}],
+                        "searchParam": [
+                            {"name": "name", "type": "string"},
+                            {"name": "connection_type", "type": "string"},
+                            {"name": "payload_type", "type": "string"},
+                            {"name": "status", "type": "string"},
+                        ],
+                    },
+                    {
+                        "type": "Location",
+                        "interaction": [{"code": "read"}, {"code": "search-type"}],
+                        "searchParam": [
+                            {"name": "name", "type": "string"},
+                            {"name": "organization_name", "type": "string"},
+                            {"name": "organization_identifier", "type": "string"},
+                            {"name": "organization_type", "type": "string"},
+                            {"name": "address", "type": "string"},
+                            {"name": "address_city", "type": "string"},
+                            {"name": "address_state", "type": "string"},
+                            {"name": "address_postalcode", "type": "string"},
+                            {"name": "address_use", "type": "string"},
+                            {"name": "near", "type": "string"},
+                        ],
+                    },
+                    {
+                        "type": "Organization",
+                        "interaction": [{"code": "read"}, {"code": "search-type"}],
+                        "searchParam": [
+                            {"name": "name", "type": "string"},
+                            {"name": "identifier", "type": "string"},
+                            {"name": "organization_type", "type": "string"},
+                            {"name": "address", "type": "string"},
+                            {"name": "address_city", "type": "string"},
+                            {"name": "address_state", "type": "string"},
+                            {"name": "address_postalcode", "type": "string"},
+                            {"name": "address_use", "type": "string"},
+                        ],
+                    },
+                    {
+                        "type": "Practitioner",
+                        "interaction": [{"code": "read"}, {"code": "search-type"}],
+                        "searchParam": [
+                            {"name": "identifier", "type": "string"},
+                            {"name": "name", "type": "string"},
+                            {"name": "gender", "type": "string"},
+                            {"name": "practitioner_type", "type": "string"},
+                            {"name": "address", "type": "string"},
+                            {"name": "address_city", "type": "string"},
+                            {"name": "address_state", "type": "string"},
+                            {"name": "address_postalcode", "type": "string"},
+                            {"name": "address_use", "type": "string"},
+                        ],
+                    },
+                    {
+                        "type": "PractitionerRole",
+                        "interaction": [{"code": "read"}, {"code": "search-type"}],
+                        "searchParam": [
+                            {"name": "practitioner_name", "type": "string"},
+                            {"name": "practitioner_gender", "type": "string"},
+                            {"name": "practitioner_type", "type": "string"},
+                            {"name": "practitioner_identifier", "type": "string"},
+                            {"name": "organization_name", "type": "string"},
+                            {"name": "organization_type", "type": "string"},
+                            {"name": "organization_identifier", "type": "string"},
+                            {"name": "location_near", "type": "string"},
+                            {"name": "location_address", "type": "string"},
+                            {"name": "location_address_city", "type": "string"},
+                            {"name": "location_address_state", "type": "string"},
+                            {"name": "location_address_postalcode", "type": "string"},
+                            {"name": "active", "type": "string"},
+                            {"name": "role", "type": "string"},
+                            {"name": "specialty", "type": "string"},
+                            {"name": "endpoint_connection_type", "type": "string"},
+                            {"name": "endpoint_payload_type", "type": "string"},
+                            {"name": "endpoint_status", "type": "string"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@app.get("/fhir", name="fhir-api-root", include_in_schema=False)
+@app.get("/fhir/", include_in_schema=False)
+def fhir_root(request: Request):
+    return FHIRJSONResponse(_resource_catalog(request))
+
+
+@app.get("/fhir/healthCheck", name="healthCheck", include_in_schema=False)
+@app.get("/fhir/healthCheck/", include_in_schema=False)
+def health_check():
+    return PlainTextResponse("healthy")
+
+
+@app.get("/fhir/docs/schema", include_in_schema=False)
+@app.get("/fhir/docs/schema/", name="schema", include_in_schema=False)
+def schema_json():
+    return openapi_json_response(get_openapi(title=app.title, version=app.version, routes=app.routes))
+
+
+@app.get("/fhir/docs", include_in_schema=False)
+@app.get("/fhir/docs/", name="schema-swagger-ui", include_in_schema=False)
+def swagger_ui():
+    return get_swagger_ui_html(
+        openapi_url="/fhir/docs/schema/",
+        title=f"{app.title} - Swagger UI",
+    )
+
+
+@app.get("/fhir/docs/redoc", include_in_schema=False)
+@app.get("/fhir/docs/redoc/", name="schema-redoc", include_in_schema=False)
+def redoc_ui():
+    return get_redoc_html(
+        openapi_url="/fhir/docs/schema/",
+        title=f"{app.title} - ReDoc",
+    )
+
+
+@app.get("/fhir/metadata", include_in_schema=False)
+@app.get("/fhir/metadata/", name="fhir-metadata", include_in_schema=False)
+def metadata(request: Request):
+    return FHIRJSONResponse(_capability_statement(request))
+
+
+@app.get(
+    "/fhir/Endpoint",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Endpoint/",
+    response_class=FHIRJSONResponse,
+    name="fhir-endpoint-list",
+)
+def endpoint_list(request: Request):
+    window = get_page_window(request)
+    result = list_endpoint_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-endpoint-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/Endpoint/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Endpoint/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-endpoint-detail",
+)
+def endpoint_detail(id: str):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("Endpoint", id)
+
+    resource = get_endpoint_resource(id)
+    if resource is None:
+        return missing_uuid_not_found("No EndpointInstance matches the given query.")
+
+    return FHIRJSONResponse(resource)
+
+
+@app.get(
+    "/fhir/OrganizationAffiliation",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/OrganizationAffiliation/",
+    response_class=FHIRJSONResponse,
+    name="fhir-organizationaffiliation-list",
+)
+def organization_affiliation_list(request: Request):
+    window = get_page_window(request)
+    result = list_organization_affiliation_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+        base_url=str(request.base_url),
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-organizationaffiliation-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/OrganizationAffiliation/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/OrganizationAffiliation/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-organizationaffiliation-detail",
+)
+def organization_affiliation_detail(id: str, request: Request):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("Organization", id)
+
+    resource = get_organization_affiliation_resource(id, base_url=str(request.base_url))
+    if resource is None:
+        return missing_uuid_not_found("No OrganizationAffiliationView matches the given query.")
+
+    return FHIRJSONResponse(resource)
+
+
+@app.get(
+    "/fhir/Organization",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Organization/",
+    response_class=FHIRJSONResponse,
+    name="fhir-organization-list",
+)
+def organization_list(request: Request):
+    window = get_page_window(request)
+    result = list_organization_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+        base_url=str(request.base_url),
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-organization-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/Organization/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Organization/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-organization-detail",
+)
+def organization_detail(id: str, request: Request):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("Organization", id)
+
+    resource = get_organization_resource(id, base_url=str(request.base_url))
+    if resource is None:
+        return missing_uuid_not_found("No OrganizationView matches the given query.")
+
+    return FHIRJSONResponse(resource)
+
+
+@app.get(
+    "/fhir/PractitionerRole",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/PractitionerRole/",
+    response_class=FHIRJSONResponse,
+    name="fhir-practitionerrole-list",
+)
+def practitioner_role_list(request: Request):
+    window = get_page_window(request)
+    result = list_practitioner_role_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+        base_url=str(request.base_url),
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-practitionerrole-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/PractitionerRole/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/PractitionerRole/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-practitionerrole-detail",
+)
+def practitioner_role_detail(id: str, request: Request):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("PractitionerRole", id)
+
+    resource = get_practitioner_role_resource(id, base_url=str(request.base_url))
+    if resource is None:
+        return missing_uuid_not_found("No ProviderToLocationView matches the given query.")
+
+    return FHIRJSONResponse(resource)
+
+
+@app.get(
+    "/fhir/Location",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Location/",
+    response_class=FHIRJSONResponse,
+    name="fhir-location-list",
+)
+def location_list(request: Request):
+    window = get_page_window(request)
+    result = list_location_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+        base_url=str(request.base_url),
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-location-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/Location/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Location/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-location-detail",
+)
+def location_detail(id: str, request: Request):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("Location", id)
+
+    resource = get_location_resource(id, base_url=str(request.base_url))
+    if resource is None:
+        return missing_uuid_not_found("No Location matches the given query.")
+
+    return FHIRJSONResponse(resource)
+
+
+@app.get(
+    "/fhir/Practitioner",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Practitioner/",
+    response_class=FHIRJSONResponse,
+    name="fhir-practitioner-list",
+)
+def practitioner_list(request: Request):
+    window = get_page_window(request)
+    result = list_practitioner_resources(
+        request.query_params,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    payload = build_bundle_envelope(
+        request,
+        route_name="fhir-practitioner-detail",
+        resources=result.resources,
+        total_count=result.total_count,
+        page=window.page,
+        page_size=window.page_size,
+    )
+    return FHIRJSONResponse(payload)
+
+
+@app.get(
+    "/fhir/Practitioner/{id}",
+    response_class=FHIRJSONResponse,
+    include_in_schema=False,
+)
+@app.get(
+    "/fhir/Practitioner/{id}/",
+    response_class=FHIRJSONResponse,
+    name="fhir-practitioner-detail",
+)
+def practitioner_detail(id: str):
+    try:
+        UUID(id)
+    except (ValueError, TypeError):
+        return malformed_id_not_found("Practitioner", id)
+
+    resource = get_practitioner_resource(id)
+    if resource is None:
+        return missing_uuid_not_found("No ProviderView matches the given query.")
+
+    return FHIRJSONResponse(resource)

--- a/backend/fastapi_app/main.py
+++ b/backend/fastapi_app/main.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import FastAPI, Request
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.responses import PlainTextResponse
 
 from .config import settings
 from .endpoint_service import get_endpoint_resource, list_endpoint_resources

--- a/backend/fastapi_app/organization_affiliation_service.py
+++ b/backend/fastapi_app/organization_affiliation_service.py
@@ -1,0 +1,126 @@
+"""OrganizationAffiliation query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import DjangoRequestAdapter, ensure_django
+
+
+@dataclass(frozen=True)
+class OrganizationAffiliationListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from npdfhir.models import OrganizationAffiliationView
+
+    return OrganizationAffiliationView.objects.all().select_related(
+        "organization",
+        "ehr_vendor",
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.organization_affiliation_filter_set import (
+        OrganizationAffiliationFilterSet,
+    )
+
+    filterset = OrganizationAffiliationFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "ehr_vendor_name": "ehr_vendor_name",
+        "organization_name": "organization_name",
+    }
+
+    if not sort_param:
+        return queryset.order_by("organization_name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["organization_name"]
+
+    return queryset.order_by(*fields)
+
+
+def _serializer_context(base_url: str) -> dict[str, DjangoRequestAdapter]:
+    return {"request": DjangoRequestAdapter(base_url=base_url)}
+
+
+def list_organization_affiliation_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+    base_url: str,
+) -> OrganizationAffiliationListResult:
+    ensure_django()
+
+    from npdfhir.serializers import OrganizationAffiliationSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = OrganizationAffiliationSerializer(
+        rows,
+        many=True,
+        context=_serializer_context(base_url),
+    ).data
+
+    return OrganizationAffiliationListResult(resources=list(resources), total_count=total_count)
+
+
+def get_organization_affiliation_resource(affiliation_id: str, *, base_url: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import OrganizationAffiliationSerializer
+
+    queryset = _get_base_queryset()
+    affiliation = queryset.filter(pk=affiliation_id).first()
+    if affiliation is None:
+        return None
+
+    return OrganizationAffiliationSerializer(
+        affiliation,
+        context=_serializer_context(base_url),
+    ).data

--- a/backend/fastapi_app/organization_service.py
+++ b/backend/fastapi_app/organization_service.py
@@ -1,0 +1,142 @@
+"""Organization query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import DjangoRequestAdapter, ensure_django
+
+
+@dataclass(frozen=True)
+class OrganizationListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from npdfhir.models import OrganizationView
+
+    return OrganizationView.objects.prefetch_related(
+        "authorized_official",
+        "ein",
+        "organization",
+        "organization__organizationtoname_set",
+        "organization__organizationtoaddress_set",
+        "organization__organizationtoaddress_set__address",
+        "organization__organizationtoaddress_set__address__address_us",
+        "organization__organizationtoaddress_set__address__address_us__state_code",
+        "organization__organizationtoaddress_set__address_use",
+        "organization__authorized_official__individualtophone_set",
+        "organization__authorized_official__individualtoname_set",
+        "organization__authorized_official__individualtoemail_set",
+        "organization__authorized_official__individualtoaddress_set",
+        "organization__authorized_official__individualtoaddress_set__address__address_us",
+        "organization__authorized_official__individualtoaddress_set__address__address_us__state_code",
+        "organization__clinicalorganization",
+        "organization__clinicalorganization__npi",
+        "organization__clinicalorganization__organizationtootherid_set",
+        "organization__clinicalorganization__organizationtootherid_set__other_id_type",
+        "organization__clinicalorganization__organizationtotaxonomy_set",
+        "organization__clinicalorganization__organizationtotaxonomy_set__nucc_code",
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.organization_filter_set import OrganizationFilterSet
+
+    filterset = OrganizationFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "name": "name",
+    }
+
+    if not sort_param:
+        return queryset.order_by("name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["name"]
+
+    return queryset.order_by(*fields)
+
+
+def _serializer_context(base_url: str) -> dict[str, DjangoRequestAdapter]:
+    return {"request": DjangoRequestAdapter(base_url=base_url)}
+
+
+def list_organization_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+    base_url: str,
+) -> OrganizationListResult:
+    ensure_django()
+
+    from npdfhir.serializers import OrganizationSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = OrganizationSerializer(
+        rows,
+        many=True,
+        context=_serializer_context(base_url),
+    ).data
+
+    return OrganizationListResult(resources=list(resources), total_count=total_count)
+
+
+def get_organization_resource(organization_id: str, *, base_url: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import OrganizationSerializer
+
+    queryset = _get_base_queryset()
+    organization = queryset.filter(organization_id=organization_id).first()
+    if organization is None:
+        return None
+
+    return OrganizationSerializer(
+        organization,
+        context=_serializer_context(base_url),
+    ).data

--- a/backend/fastapi_app/pagination.py
+++ b/backend/fastapi_app/pagination.py
@@ -1,0 +1,85 @@
+"""Pagination helpers matching the current Django API envelope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
+
+from fastapi import Request
+
+from .config import settings
+
+
+@dataclass(frozen=True)
+class PageWindow:
+    page: int
+    page_size: int
+    offset: int
+    limit: int
+
+
+def _parse_positive_int(raw_value: str | None, default: int) -> int:
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+
+    return value if value > 0 else default
+
+
+def get_page_window(request: Request) -> PageWindow:
+    page = _parse_positive_int(request.query_params.get("page"), 1)
+    requested_page_size = _parse_positive_int(
+        request.query_params.get("page_size"),
+        settings.default_page_size,
+    )
+    page_size = min(requested_page_size, settings.max_page_size)
+    offset = (page - 1) * page_size
+    return PageWindow(page=page, page_size=page_size, offset=offset, limit=page_size)
+
+
+def build_bundle_envelope(
+    request: Request,
+    route_name: str,
+    resources: list[dict],
+    total_count: int,
+    page: int,
+    page_size: int,
+) -> dict:
+    def canonicalize_resource_url(url: str) -> str:
+        parts = urlsplit(url)
+        path = parts.path.rstrip("/") or "/"
+        return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
+
+    entries = [
+        {
+            "fullUrl": canonicalize_resource_url(str(request.url_for(route_name, id=resource["id"]))),
+            "resource": resource,
+        }
+        for resource in resources
+    ]
+
+    page_count = (total_count + page_size - 1) // page_size if total_count else 0
+
+    next_url = None
+    if total_count and page < page_count:
+        next_url = str(request.url.include_query_params(page=page + 1, page_size=page_size))
+
+    previous_url = None
+    if page > 1:
+        previous_url = str(request.url.include_query_params(page=page - 1, page_size=page_size))
+
+    return {
+        "count": total_count,
+        "next": next_url,
+        "previous": previous_url,
+        "results": {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "total": len(entries),
+            "entry": entries,
+        },
+    }

--- a/backend/fastapi_app/practitioner_role_service.py
+++ b/backend/fastapi_app/practitioner_role_service.py
@@ -1,0 +1,127 @@
+"""PractitionerRole query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import DjangoRequestAdapter, ensure_django
+
+
+@dataclass(frozen=True)
+class PractitionerRoleListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from npdfhir.models import ProviderToLocationView
+
+    return (
+        ProviderToLocationView.objects.all()
+        .select_related("location")
+        .prefetch_related("provider_to_organization", "location__locationtoendpointinstance_set")
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.practitioner_role_filter_set import PractitionerRoleFilterSet
+
+    filterset = PractitionerRoleFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "location_name": "location_name",
+        "practitioner_first_name": "practitioner_first_name",
+        "practitioner_last_name": "practitioner_last_name",
+        "organization_name": "organization_name",
+    }
+
+    if not sort_param:
+        return queryset.order_by("location_name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["location_name"]
+
+    return queryset.order_by(*fields)
+
+
+def _serializer_context(base_url: str) -> dict[str, DjangoRequestAdapter]:
+    return {"request": DjangoRequestAdapter(base_url=base_url)}
+
+
+def list_practitioner_role_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+    base_url: str,
+) -> PractitionerRoleListResult:
+    ensure_django()
+
+    from npdfhir.serializers import PractitionerRoleSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = PractitionerRoleSerializer(
+        rows,
+        many=True,
+        context=_serializer_context(base_url),
+    ).data
+
+    return PractitionerRoleListResult(resources=list(resources), total_count=total_count)
+
+
+def get_practitioner_role_resource(role_id: str, *, base_url: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import PractitionerRoleSerializer
+
+    queryset = _get_base_queryset()
+    role = queryset.filter(id=role_id).first()
+    if role is None:
+        return None
+
+    return PractitionerRoleSerializer(
+        role,
+        context=_serializer_context(base_url),
+    ).data

--- a/backend/fastapi_app/practitioner_service.py
+++ b/backend/fastapi_app/practitioner_service.py
@@ -1,0 +1,133 @@
+"""Practitioner query helpers for the FastAPI experiment server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ._django import ensure_django
+
+
+@dataclass(frozen=True)
+class PractitionerListResult:
+    resources: list[dict]
+    total_count: int
+
+
+def _build_filter_querydict(query_params: Mapping[str, str]):
+    ensure_django()
+
+    from django.http import QueryDict
+
+    querydict = QueryDict("", mutable=True)
+    for key, value in query_params.items():
+        querydict.appendlist(key, value)
+    return querydict
+
+
+def _get_base_queryset():
+    ensure_django()
+
+    from django.db.models import Prefetch
+
+    from npdfhir.models import IndividualToAddress, ProviderView
+
+    return ProviderView.objects.all().prefetch_related(
+        "provider__individual",
+        "provider__npi",
+        "provider",
+        Prefetch(
+            "provider__individual__individualtoaddress_set",
+            queryset=IndividualToAddress.objects.select_related(
+                "address_use",
+                "address__address_us",
+                "address__address_us__state_code",
+            ),
+        ),
+        "provider__individual__individualtophone_set",
+        "provider__individual__individualtoemail_set",
+        "provider__individual__individualtoname_set",
+        "provider__providertootherid_set",
+        "provider__providertootherid_set__other_id_type",
+        "provider__providertootherid_set__state_code",
+        "provider__providertotaxonomy_set",
+        "provider__providertotaxonomy_set__nucc_code",
+    )
+
+
+def _apply_filters(queryset, query_params: Mapping[str, str]):
+    ensure_django()
+
+    from npdfhir.filters.practitioner_filter_set import PractitionerFilterSet
+
+    filterset = PractitionerFilterSet(
+        data=_build_filter_querydict(query_params),
+        queryset=queryset,
+    )
+    return filterset.qs
+
+
+def _apply_ordering(queryset, sort_param: str | None):
+    ordering_map = {
+        "last_name": "last_name",
+        "first_name": "first_name",
+        "npi_value": "npi__npi",
+    }
+
+    if not sort_param:
+        return queryset.order_by("last_name", "first_name")
+
+    fields = []
+    for raw_field in sort_param.split(","):
+        raw_field = raw_field.strip()
+        if not raw_field:
+            continue
+
+        descending = raw_field.startswith("-")
+        field_name = raw_field[1:] if descending else raw_field
+        resolved_field = ordering_map.get(field_name)
+        if not resolved_field:
+            continue
+
+        fields.append(f"-{resolved_field}" if descending else resolved_field)
+
+    if not fields:
+        fields = ["last_name", "first_name"]
+
+    return queryset.order_by(*fields)
+
+
+def list_practitioner_resources(
+    query_params: Mapping[str, str],
+    *,
+    page: int,
+    page_size: int,
+) -> PractitionerListResult:
+    ensure_django()
+
+    from npdfhir.serializers import PractitionerSerializer
+
+    queryset = _get_base_queryset()
+    queryset = _apply_filters(queryset, query_params)
+    queryset = _apply_ordering(queryset, query_params.get("_sort"))
+
+    total_count = queryset.count()
+    offset = (page - 1) * page_size
+    rows = list(queryset[offset : offset + page_size])
+    resources = PractitionerSerializer(rows, many=True).data
+
+    return PractitionerListResult(resources=list(resources), total_count=total_count)
+
+
+def get_practitioner_resource(practitioner_id: str) -> dict | None:
+    ensure_django()
+
+    from npdfhir.serializers import PractitionerSerializer
+
+    queryset = _get_base_queryset()
+    provider = queryset.filter(provider_id=practitioner_id).first()
+    if provider is None:
+        return None
+
+    return PractitionerSerializer(provider).data
+

--- a/backend/fastapi_app/responses.py
+++ b/backend/fastapi_app/responses.py
@@ -1,0 +1,41 @@
+"""Response helpers for FHIR and docs endpoints."""
+
+from __future__ import annotations
+
+from html import escape
+import json
+
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import HTMLResponse, JSONResponse
+
+
+FHIR_MEDIA_TYPE = "application/fhir+json"
+OPENAPI_MEDIA_TYPE = "application/vnd.oai.openapi+json"
+
+
+class FHIRJSONResponse(JSONResponse):
+    media_type = FHIR_MEDIA_TYPE
+
+    def render(self, content) -> bytes:
+        return json.dumps(
+            jsonable_encoder(content),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
+def malformed_id_not_found(resource_type: str, resource_id: str) -> HTMLResponse:
+    return HTMLResponse(
+        content=f"{resource_type} {escape(resource_id)} not found",
+        status_code=404,
+        media_type="text/html",
+    )
+
+
+def missing_uuid_not_found(detail: str) -> FHIRJSONResponse:
+    return FHIRJSONResponse({"detail": detail}, status_code=404)
+
+
+def openapi_json_response(payload: dict) -> JSONResponse:
+    return JSONResponse(payload, media_type=OPENAPI_MEDIA_TYPE)

--- a/backend/npdfhir/serializers.py
+++ b/backend/npdfhir/serializers.py
@@ -604,8 +604,10 @@ class PractitionerRoleSerializer(serializers.Serializer):
         practitioner_role = PractitionerRole()
         practitioner_role.id = str(instance.id)
         practitioner_role.active = instance.active
-        practitioner_display = (
-            instance.practitioner_first_name + " " + instance.practitioner_last_name
+        practitioner_display = " ".join(
+            part
+            for part in [instance.practitioner_first_name, instance.practitioner_last_name]
+            if part
         )
         practitioner_role.practitioner = genReference(
             "fhir-practitioner-detail",

--- a/backend/npdfhir/tests/test_practitioner_role.py
+++ b/backend/npdfhir/tests/test_practitioner_role.py
@@ -143,6 +143,16 @@ class PractitionerRoleViewSetTestCase(APITestCase):
         # Generate test data to retrieve specific practitioner role
         DefaultPractitionerRole(id="cad156c0-87fb-489b-bf5e-f15c95ee771e")
 
+        # Generate a practitioner role whose practitioner has no first name.
+        null_first_name_role = DefaultPractitionerRole(
+            practitioner=DefaultPractitioner(
+                individual=DefaultIndividual(
+                    names=[DefaultName(first_name=None, last_name="Brown")]
+                )
+            )
+        )
+        cls.null_first_name_practitioner_role_id = null_first_name_role.id
+
         # Generate test data for testing organization identifier filtering
         DefaultPractitionerRole(organization=DefaultOrganization(npi=DefaultNPI(npi=1000000001)))
         DefaultPractitionerRole(
@@ -161,6 +171,16 @@ class PractitionerRoleViewSetTestCase(APITestCase):
         response = self.client.get(url)
         assert_fhir_response(self, response)
         assert_has_results(self, response)
+
+    def test_retrieve_handles_missing_practitioner_first_name(self):
+        url = reverse(
+            "fhir-practitionerrole-detail",
+            kwargs={"id": self.null_first_name_practitioner_role_id},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["practitioner"]["display"], "Brown")
 
     # Sorting tests
     """def test_list_in_proper_order(self):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ fhir.resources==8.1.0
 fhir_core==1.1.3
 geopy==2.4.1
 gunicorn==23.0.0
+httpx==0.28.1
 idna==3.10
 markdown-it-py==3.0.0
 mdurl==0.1.2
@@ -52,4 +53,6 @@ typing_extensions==4.14.0
 unittest-xml-reporting==3.2.0
 urllib3==2.6.3
 ddtrace==4.3.0
+fastapi==0.135.2
+uvicorn==0.35.0
 whitenoise==6.11.0

--- a/backend/tests_fastapi/__init__.py
+++ b/backend/tests_fastapi/__init__.py
@@ -1,0 +1,2 @@
+"""FastAPI-specific tests."""
+

--- a/backend/tests_fastapi/test_endpoint.py
+++ b/backend/tests_fastapi/test_endpoint.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.endpoint_service import EndpointListResult
+from fastapi_app.main import app
+
+
+class EndpointEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_endpoint_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = EndpointListResult(
+            resources=[
+                {
+                    "resourceType": "Endpoint",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/Endpoint/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_endpoint_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "Endpoint",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get("/fhir/Endpoint/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "Endpoint")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/Endpoint/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "Endpoint 999999 not found")
+
+    @patch("fastapi_app.main.get_endpoint_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get("/fhir/Endpoint/12300000-0000-0000-0000-000000000123")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No EndpointInstance matches the given query.",
+        )

--- a/backend/tests_fastapi/test_health.py
+++ b/backend/tests_fastapi/test_health.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.main import app
+
+
+class HealthEndpointTestCase(TestCase):
+    def test_healthcheck_returns_plain_text(self):
+        client = TestClient(app)
+        response = client.get("/fhir/healthCheck")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "healthy")
+

--- a/backend/tests_fastapi/test_location.py
+++ b/backend/tests_fastapi/test_location.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.location_service import LocationListResult
+from fastapi_app.main import app
+
+
+class LocationEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_location_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = LocationListResult(
+            resources=[
+                {
+                    "resourceType": "Location",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/Location/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_location_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "Location",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get("/fhir/Location/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "Location")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/Location/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "Location 999999 not found")
+
+    @patch("fastapi_app.main.get_location_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get("/fhir/Location/12300000-0000-0000-0000-000000000123")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No Location matches the given query.",
+        )

--- a/backend/tests_fastapi/test_organization.py
+++ b/backend/tests_fastapi/test_organization.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.main import app
+from fastapi_app.organization_service import OrganizationListResult
+
+
+class OrganizationEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_organization_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = OrganizationListResult(
+            resources=[
+                {
+                    "resourceType": "Organization",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/Organization/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_organization_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "Organization",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get("/fhir/Organization/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "Organization")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/Organization/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "Organization 999999 not found")
+
+    @patch("fastapi_app.main.get_organization_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get("/fhir/Organization/12300000-0000-0000-0000-000000000123")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No OrganizationView matches the given query.",
+        )

--- a/backend/tests_fastapi/test_organization_affiliation.py
+++ b/backend/tests_fastapi/test_organization_affiliation.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.main import app
+from fastapi_app.organization_affiliation_service import OrganizationAffiliationListResult
+
+
+class OrganizationAffiliationEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_organization_affiliation_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = OrganizationAffiliationListResult(
+            resources=[
+                {
+                    "resourceType": "OrganizationAffiliation",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/OrganizationAffiliation/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_organization_affiliation_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "OrganizationAffiliation",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get(
+            "/fhir/OrganizationAffiliation/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "OrganizationAffiliation")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/OrganizationAffiliation/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "Organization 999999 not found")
+
+    @patch("fastapi_app.main.get_organization_affiliation_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get(
+            "/fhir/OrganizationAffiliation/12300000-0000-0000-0000-000000000123"
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No OrganizationAffiliationView matches the given query.",
+        )

--- a/backend/tests_fastapi/test_practitioner.py
+++ b/backend/tests_fastapi/test_practitioner.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.main import app
+from fastapi_app.practitioner_service import PractitionerListResult
+
+
+class PractitionerEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_practitioner_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = PractitionerListResult(
+            resources=[
+                {
+                    "resourceType": "Practitioner",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/Practitioner/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_practitioner_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "Practitioner",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get("/fhir/Practitioner/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "Practitioner")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/Practitioner/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "Practitioner 999999 not found")
+
+    @patch("fastapi_app.main.get_practitioner_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get("/fhir/Practitioner/12300000-0000-0000-0000-000000000123")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No ProviderView matches the given query.",
+        )

--- a/backend/tests_fastapi/test_practitioner_role.py
+++ b/backend/tests_fastapi/test_practitioner_role.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from fastapi_app.main import app
+from fastapi_app.practitioner_role_service import PractitionerRoleListResult
+
+
+class PractitionerRoleEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    @patch("fastapi_app.main.list_practitioner_role_resources")
+    def test_list_wraps_results_in_expected_envelope(self, mock_list_resources):
+        mock_list_resources.return_value = PractitionerRoleListResult(
+            resources=[
+                {
+                    "resourceType": "PractitionerRole",
+                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                }
+            ],
+            total_count=1,
+        )
+
+        response = self.client.get("/fhir/PractitionerRole/?page_size=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"]["resourceType"], "Bundle")
+        self.assertEqual(payload["results"]["total"], 1)
+        self.assertEqual(
+            payload["results"]["entry"][0]["resource"]["id"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+
+    @patch("fastapi_app.main.get_practitioner_role_resource")
+    def test_retrieve_returns_fhir_json(self, mock_get_resource):
+        mock_get_resource.return_value = {
+            "resourceType": "PractitionerRole",
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = self.client.get(
+            "/fhir/PractitionerRole/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(response.json()["resourceType"], "PractitionerRole")
+
+    def test_malformed_id_returns_text_html_404(self):
+        response = self.client.get("/fhir/PractitionerRole/999999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "text/html; charset=utf-8")
+        self.assertEqual(response.text, "PractitionerRole 999999 not found")
+
+    @patch("fastapi_app.main.get_practitioner_role_resource")
+    def test_missing_uuid_returns_fhir_json_404(self, mock_get_resource):
+        mock_get_resource.return_value = None
+
+        response = self.client.get(
+            "/fhir/PractitionerRole/12300000-0000-0000-0000-000000000123"
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-type"], "application/fhir+json")
+        self.assertEqual(
+            response.json()["detail"],
+            "No ProviderToLocationView matches the given query.",
+        )

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -1,0 +1,2 @@
+"""Utility tooling packages for backend development."""
+

--- a/backend/tools/api_parity/__init__.py
+++ b/backend/tools/api_parity/__init__.py
@@ -1,0 +1,2 @@
+"""Dual-server API parity tooling."""
+

--- a/backend/tools/api_parity/corpus/README.md
+++ b/backend/tools/api_parity/corpus/README.md
@@ -1,0 +1,9 @@
+# API Parity Corpus
+
+These YAML files define request cases that should be replayed against:
+
+- the current Django server
+- the experimental FastAPI server
+
+The initial corpus is intentionally small and focused on the first parity slice.
+

--- a/backend/tools/api_parity/corpus/endpoint.yaml
+++ b/backend/tools/api_parity/corpus/endpoint.yaml
@@ -1,0 +1,16 @@
+resource: Endpoint
+cases:
+  - name: list-default
+    path: /fhir/Endpoint/?page_size=1
+  - name: list-sort-desc-name
+    path: /fhir/Endpoint/?page_size=1&_sort=-name
+  - name: name-search
+    path: /fhir/Endpoint/?page_size=1&name=88
+  - name: connection-type
+    path: /fhir/Endpoint/?page_size=1&connection_type=hl7-fhir-rest
+  - name: retrieve-success
+    path: /fhir/Endpoint/1e9cdb1a-4274-49fe-bb59-f3751c1ae66e/
+  - name: malformed-id
+    path: /fhir/Endpoint/999999
+  - name: missing-uuid
+    path: /fhir/Endpoint/12300000-0000-0000-0000-000000000123

--- a/backend/tools/api_parity/corpus/location.yaml
+++ b/backend/tools/api_parity/corpus/location.yaml
@@ -1,0 +1,16 @@
+resource: Location
+cases:
+  - name: list-default
+    path: /fhir/Location/?page_size=1
+  - name: list-sort-desc-name
+    path: /fhir/Location/?page_size=1&_sort=-name
+  - name: name-search
+    path: /fhir/Location/?page_size=1&name=1ST
+  - name: address-state
+    path: /fhir/Location/?page_size=1&address_state=IN
+  - name: retrieve-success
+    path: /fhir/Location/7e784e10-1875-4d57-bd75-6115e267641b/
+  - name: malformed-id
+    path: /fhir/Location/999999
+  - name: missing-uuid
+    path: /fhir/Location/12300000-0000-0000-0000-000000000123

--- a/backend/tools/api_parity/corpus/organization.yaml
+++ b/backend/tools/api_parity/corpus/organization.yaml
@@ -1,0 +1,23 @@
+resource: Organization
+cases:
+  - name: list-default
+    method: GET
+    path: /fhir/Organization/?page_size=1
+  - name: list-sort-name
+    method: GET
+    path: /fhir/Organization/?page_size=1&_sort=name
+  - name: identifier-npi
+    method: GET
+    path: /fhir/Organization/?page_size=1&identifier=NPI|1679576367
+  - name: name-search
+    method: GET
+    path: /fhir/Organization/?page_size=1&name=CHOICE
+  - name: retrieve-success
+    method: GET
+    path: /fhir/Organization/3ac907f0-c7d0-484e-ad0e-653dd011a55b/
+  - name: malformed-id
+    method: GET
+    path: /fhir/Organization/999999
+  - name: missing-uuid
+    method: GET
+    path: /fhir/Organization/12300000-0000-0000-0000-000000000123

--- a/backend/tools/api_parity/corpus/organization_affiliation.yaml
+++ b/backend/tools/api_parity/corpus/organization_affiliation.yaml
@@ -1,0 +1,14 @@
+resource: OrganizationAffiliation
+cases:
+  - name: list-default
+    path: /fhir/OrganizationAffiliation/?page_size=1
+  - name: participating-name
+    path: /fhir/OrganizationAffiliation/?page_size=1&participating_organization_name=COLORECTAL
+  - name: location-state
+    path: /fhir/OrganizationAffiliation/?page_size=1&location_address_state=KY
+  - name: retrieve-success
+    path: /fhir/OrganizationAffiliation/42309dab-7864-5b76-b0f0-f0e5d24ced00/
+  - name: malformed-id
+    path: /fhir/OrganizationAffiliation/999999
+  - name: missing-uuid
+    path: /fhir/OrganizationAffiliation/12300000-0000-0000-0000-000000000123

--- a/backend/tools/api_parity/corpus/practitioner.yaml
+++ b/backend/tools/api_parity/corpus/practitioner.yaml
@@ -1,0 +1,21 @@
+resource: Practitioner
+cases:
+  - name: list-default
+    method: GET
+    path: /fhir/Practitioner/?page_size=1
+  - name: list-sort-first-last
+    method: GET
+    path: /fhir/Practitioner/?page_size=1&_sort=first_name,last_name
+  - name: identifier-npi
+    method: GET
+    path: /fhir/Practitioner/?page_size=1&identifier=NPI|1003000100
+  - name: name-search
+    method: GET
+    path: /fhir/Practitioner/?page_size=1&name=Solomon
+  - name: malformed-id
+    method: GET
+    path: /fhir/Practitioner/999999
+  - name: missing-uuid
+    method: GET
+    path: /fhir/Practitioner/12300000-0000-0000-0000-000000000123
+

--- a/backend/tools/api_parity/corpus/practitioner_role.yaml
+++ b/backend/tools/api_parity/corpus/practitioner_role.yaml
@@ -1,0 +1,16 @@
+resource: PractitionerRole
+cases:
+  - name: list-default
+    path: /fhir/PractitionerRole/?page_size=1
+  - name: practitioner-identifier
+    path: /fhir/PractitionerRole/?page_size=1&practitioner_identifier=NPI|1255334165
+  - name: organization-identifier
+    path: /fhir/PractitionerRole/?page_size=1&organization_identifier=NPI|1316940224
+  - name: endpoint-connection-type
+    path: /fhir/PractitionerRole/?page_size=1&endpoint_connection_type=hl7-fhir-rest
+  - name: retrieve-success
+    path: /fhir/PractitionerRole/eb60df9a-17ab-4bc8-b726-9165d23dcfc2/
+  - name: malformed-id
+    path: /fhir/PractitionerRole/999999
+  - name: missing-uuid
+    path: /fhir/PractitionerRole/12300000-0000-0000-0000-000000000123

--- a/backend/tools/api_parity/diff.py
+++ b/backend/tools/api_parity/diff.py
@@ -1,0 +1,40 @@
+"""Diff helpers for parity reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    classification: str
+    status_match: bool
+    content_type_match: bool
+    body_match: bool
+
+
+def classify_response_pair(
+    *,
+    django_status: int,
+    fastapi_status: int,
+    django_content_type: str | None,
+    fastapi_content_type: str | None,
+    django_body: Any,
+    fastapi_body: Any,
+) -> ComparisonResult:
+    status_match = django_status == fastapi_status
+    content_type_match = django_content_type == fastapi_content_type
+    body_match = django_body == fastapi_body
+
+    classification = (
+        "exact_match" if status_match and content_type_match and body_match else "contract_mismatch"
+    )
+
+    return ComparisonResult(
+        classification=classification,
+        status_match=status_match,
+        content_type_match=content_type_match,
+        body_match=body_match,
+    )
+

--- a/backend/tools/api_parity/normalize.py
+++ b/backend/tools/api_parity/normalize.py
@@ -1,0 +1,59 @@
+"""Normalization helpers for Django-vs-FastAPI response comparison."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+from typing import Any
+
+
+IGNORED_HEADERS = {
+    "date",
+    "server",
+    "content-length",
+    "vary",
+    "x-frame-options",
+    "referrer-policy",
+    "cross-origin-opener-policy",
+    "set-cookie",
+    "djdt-store-id",
+    "server-timing",
+}
+
+
+def normalize_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {
+        key.lower(): value
+        for key, value in headers.items()
+        if key.lower() not in IGNORED_HEADERS
+    }
+
+
+def _normalize_url(value: str, local_netlocs: set[str]) -> str:
+    parts = urlsplit(value)
+    if not parts.scheme or not parts.netloc:
+        return value
+    if parts.netloc not in local_netlocs:
+        return value
+
+    normalized_query = "&".join(
+        f"{key}={query_value}" for key, query_value in sorted(parse_qsl(parts.query, keep_blank_values=True))
+    )
+    normalized_path = parts.path.rstrip("/") or "/"
+    return urlunsplit(("http", "__BASE__", normalized_path, normalized_query, ""))
+
+
+def _normalize_json(value: Any, local_netlocs: set[str]) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_json(item, local_netlocs) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_json(item, local_netlocs) for item in value]
+    if isinstance(value, str):
+        return _normalize_url(value, local_netlocs)
+    return value
+
+
+def normalize_body(content_type: str | None, body: str, *, local_netlocs: set[str] | None = None) -> Any:
+    if content_type and "json" in content_type:
+        return _normalize_json(json.loads(body), local_netlocs or set())
+    return body

--- a/backend/tools/api_parity/runner.py
+++ b/backend/tools/api_parity/runner.py
@@ -1,0 +1,144 @@
+"""Run a request corpus against Django and FastAPI and compare responses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import requests
+import yaml
+
+from .diff import classify_response_pair
+from .normalize import normalize_body, normalize_headers
+
+
+def _read_corpus(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _fetch(
+    base_url: str,
+    path: str,
+    auth: tuple[str, str] | None,
+    *,
+    local_netlocs: set[str],
+):
+    response = requests.get(
+        f"{base_url.rstrip('/')}{path}",
+        auth=auth,
+        headers={"Accept": "application/fhir+json"},
+        timeout=30,
+    )
+    return {
+        "status": response.status_code,
+        "headers": normalize_headers(dict(response.headers)),
+        "raw_body": response.text,
+        "body": normalize_body(
+            response.headers.get("content-type"),
+            response.text,
+            local_netlocs=local_netlocs,
+        ),
+    }
+
+
+def _parse_auth(username: str | None, password: str | None):
+    if username and password:
+        return (username, password)
+    return None
+
+
+def run_corpus(
+    *,
+    corpus_path: Path,
+    django_base_url: str,
+    fastapi_base_url: str,
+    django_auth: tuple[str, str] | None = None,
+    fastapi_auth: tuple[str, str] | None = None,
+):
+    corpus = _read_corpus(corpus_path)
+    local_netlocs = {
+        urlsplit(django_base_url).netloc,
+        urlsplit(fastapi_base_url).netloc,
+    }
+    report = {
+        "corpus": str(corpus_path),
+        "resource": corpus.get("resource"),
+        "cases": [],
+    }
+    failures = 0
+
+    for case in corpus.get("cases", []):
+        django_result = _fetch(
+            django_base_url,
+            case["path"],
+            django_auth,
+            local_netlocs=local_netlocs,
+        )
+        fastapi_result = _fetch(
+            fastapi_base_url,
+            case["path"],
+            fastapi_auth,
+            local_netlocs=local_netlocs,
+        )
+
+        comparison = classify_response_pair(
+            django_status=django_result["status"],
+            fastapi_status=fastapi_result["status"],
+            django_content_type=django_result["headers"].get("content-type"),
+            fastapi_content_type=fastapi_result["headers"].get("content-type"),
+            django_body=django_result["body"],
+            fastapi_body=fastapi_result["body"],
+        )
+
+        case_report = {
+            "name": case["name"],
+            "path": case["path"],
+            "django": django_result,
+            "fastapi": fastapi_result,
+            "comparison": {
+                "classification": comparison.classification,
+                "status_match": comparison.status_match,
+                "content_type_match": comparison.content_type_match,
+                "body_match": comparison.body_match,
+            },
+        }
+        report["cases"].append(case_report)
+        if comparison.classification != "exact_match":
+            failures += 1
+
+    return report, failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare Django and FastAPI responses.")
+    parser.add_argument("--corpus", required=True, type=Path)
+    parser.add_argument("--django-base-url", required=True)
+    parser.add_argument("--fastapi-base-url", required=True)
+    parser.add_argument("--django-username")
+    parser.add_argument("--django-password")
+    parser.add_argument("--fastapi-username")
+    parser.add_argument("--fastapi-password")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    django_auth = _parse_auth(args.django_username, args.django_password)
+    fastapi_auth = _parse_auth(args.fastapi_username, args.fastapi_password)
+    report, failures = run_corpus(
+        corpus_path=args.corpus,
+        django_base_url=args.django_base_url,
+        fastapi_base_url=args.fastapi_base_url,
+        django_auth=django_auth,
+        fastapi_auth=fastapi_auth,
+    )
+
+    if args.output:
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True))
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tools/api_parity/suite.py
+++ b/backend/tools/api_parity/suite.py
@@ -1,0 +1,75 @@
+"""Run every parity corpus and emit a single summary report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .runner import _parse_auth, run_corpus
+
+
+def _default_corpora_dir() -> Path:
+    return Path(__file__).resolve().parent / "corpus"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run all API parity corpora.")
+    parser.add_argument("--corpora-dir", type=Path, default=_default_corpora_dir())
+    parser.add_argument("--django-base-url", required=True)
+    parser.add_argument("--fastapi-base-url", required=True)
+    parser.add_argument("--django-username")
+    parser.add_argument("--django-password")
+    parser.add_argument("--fastapi-username")
+    parser.add_argument("--fastapi-password")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    django_auth = _parse_auth(args.django_username, args.django_password)
+    fastapi_auth = _parse_auth(args.fastapi_username, args.fastapi_password)
+
+    corpora = sorted(args.corpora_dir.glob("*.yaml"))
+    suite_report = {
+        "django_base_url": args.django_base_url,
+        "fastapi_base_url": args.fastapi_base_url,
+        "corpora": [],
+        "summary": {
+            "corpora_total": len(corpora),
+            "corpora_with_failures": 0,
+            "cases_total": 0,
+            "cases_failed": 0,
+        },
+    }
+
+    for corpus_path in corpora:
+        report, failures = run_corpus(
+            corpus_path=corpus_path,
+            django_base_url=args.django_base_url,
+            fastapi_base_url=args.fastapi_base_url,
+            django_auth=django_auth,
+            fastapi_auth=fastapi_auth,
+        )
+        case_total = len(report["cases"])
+        suite_report["corpora"].append(
+            {
+                "corpus": str(corpus_path),
+                "resource": report.get("resource"),
+                "case_total": case_total,
+                "failures": failures,
+                "status": "pass" if failures == 0 else "fail",
+            }
+        )
+        suite_report["summary"]["cases_total"] += case_total
+        suite_report["summary"]["cases_failed"] += failures
+        if failures:
+            suite_report["summary"]["corpora_with_failures"] += 1
+
+    if args.output:
+        args.output.write_text(json.dumps(suite_report, indent=2, sort_keys=True))
+
+    print(json.dumps(suite_report, indent=2, sort_keys=True))
+    return 1 if suite_report["summary"]["cases_failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,39 @@ services:
       db-migrations:
         condition: service_completed_successfully
 
+  fastapi-web:
+    build:
+      context: ./backend
+    container_name: npd-fastapi
+    env_file:
+      - path: .env
+        required: false
+    entrypoint: []
+    command: uvicorn fastapi_app.main:app --host 0.0.0.0 --port 8001 --reload
+    environment:
+      NPD_DJANGO_SECRET: ${NPD_DJANGO_SECRET:-_pth2#=k8-wf-_^t%2))it+3..8la^@@97^#ock7.v=@792w7}
+      DEBUG: ${DEBUG:-True}
+      DJANGO_LOGLEVEL: ${DJANGO_LOGLEVEL:-INFO}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1,0.0.0.0}
+      NPD_DB_ENGINE: ${NPD_DB_ENGINE:-django.contrib.gis.db.backends.postgis}
+      NPD_DB_NAME: ${NPD_DB_NAME:-npd_development}
+      NPD_DB_USER: ${NPD_DB_USER:-postgres}
+      NPD_DB_PASSWORD: ${NPD_DB_PASSWORD:-postgres}
+      NPD_DB_HOST: ${NPD_DB_HOST:-db}
+      NPD_DB_PORT: ${NPD_DB_PORT:-5432}
+      NPD_REQUIRE_AUTHENTICATION: False
+    ports:
+      - '8001:8001'
+    volumes:
+      - './backend/:/app'
+      - ./backend/artifacts:/app/artifacts:rw
+    restart: on-failure:10
+    depends_on:
+      db:
+        condition: service_healthy
+      db-migrations:
+        condition: service_completed_successfully
+
   db:
     image: 'postgis/postgis:17-3.5'
     platform: linux/x86_64
@@ -48,7 +81,7 @@ services:
       POSTGRES_PASSWORD: ${NPD_DB_PASSWORD:-postgres}
       PGUSER: ${NPD_DB_USER:-postgres}
     ports:
-      - ${NPD_DB_PORT:-5432}:5432
+      - ${NPD_DB_HOST_PORT:-5432}:5432
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./flyway/db-init:/docker-entrypoint-initdb.d/


### PR DESCRIPTION
## Summary

This draft PR adds an experimental FastAPI-based FHIR server alongside the existing Django implementation, plus a parity harness for running the two servers against each other.

The intent here is not cutover yet. The goal is to make it possible to:
- run Django and FastAPI side by side locally
- compare responses mechanically across a focused request corpus
- prove parity resource-by-resource before any deployment or routing change

## What This Adds

- a new FastAPI app under `backend/fastapi_app`
- parity-focused routes for:
  - `Practitioner`
  - `Organization`
  - `Location`
  - `Endpoint`
  - `PractitionerRole`
  - `OrganizationAffiliation`
- a response/pagination layer that matches the current FHIR envelope and error behavior
- a parity harness under `backend/tools/api_parity`
  - per-resource corpora
  - single-corpus runner
  - multi-corpus suite runner
- focused FastAPI tests under `backend/tests_fastapi`
- local compose support for running the FastAPI server next to the existing Django app
- Makefile targets for running the FastAPI app, tests, and parity checks

## Implementation Approach

This branch intentionally reuses the existing Django queryset/filter/serializer logic from the `npdfhir` app wherever possible.

That keeps the experiment parity-first:
- avoid reinterpreting current behavior too early
- preserve current quirks where they are part of the observable contract
- make the harness the primary gate for future rewrites of the internal query layer

## Validation

Local validation completed:
- `python -m unittest discover -s tests_fastapi -p 'test_*.py'`
  - `25` tests passing
- `python -m tools.api_parity.suite --django-base-url http://127.0.0.1:8000 --fastapi-base-url http://127.0.0.1:8001`
  - `6` corpora
  - `40` cases
  - `0` failures

Green parity corpora currently cover:
- `Practitioner`
- `Organization`
- `Location`
- `Endpoint`
- `PractitionerRole`
- `OrganizationAffiliation`

## Not Yet In Scope

- production or dev ECS deployment changes
- auth/cutover work
- deeper docs/schema/metadata parity beyond the current experiment surface
- replacement of the internal Django ORM/filter/serializer dependency

## Why Draft

This is a useful experimental checkpoint, but it is still a draft because the next likely work is:
- tighten docs and capability-statement parity
- broaden corpus coverage for more filter shapes
- decide how we want to test this in dev AWS infrastructure
- eventually peel the FastAPI server away from direct reuse of Django internals
