### PR TITLE
Unified Search Experience

### DIFF
--- a/frontend/src/@types/unifiedSearch.d.ts
+++ b/frontend/src/@types/unifiedSearch.d.ts
@@ -1,0 +1,14 @@
+interface UnifiedSearchParams {
+  providerName?: string
+  npi?: string
+  location?: string
+  organizationName?: string
+}
+
+interface UnifiedSearchURLParams extends PaginationParams {
+  provider_name?: string
+  npi?: string
+  location?: string
+  organization_name?: string
+  sort?: string
+}

--- a/frontend/src/components/UnifiedSearchForm.module.css
+++ b/frontend/src/components/UnifiedSearchForm.module.css
@@ -1,0 +1,17 @@
+.actionsRow {
+  padding-bottom: 1.5rem;
+}
+
+.clearButton {
+  background: transparent;
+  border: 1px solid var(--color-primary-dark);
+  color: var(--color-primary-darkest);
+  text-decoration: none;
+}
+
+.clearButton:hover,
+.clearButton:focus {
+  background: rgba(0, 94, 162, 0.08);
+  color: var(--color-primary-darkest);
+  text-decoration: none;
+}

--- a/frontend/src/components/UnifiedSearchForm.test.tsx
+++ b/frontend/src/components/UnifiedSearchForm.test.tsx
@@ -1,0 +1,193 @@
+import { screen, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render } from "../../tests/render"
+import { UnifiedSearchForm } from "./UnifiedSearchForm"
+
+const makeProps = (
+  overrides: Partial<Parameters<typeof UnifiedSearchForm>[0]> = {},
+) => ({
+  values: { providerName: "", organizationName: "", npi: "", location: "" },
+  onChange: vi.fn(),
+  onSearch: vi.fn(),
+  onClear: vi.fn(),
+  isLoading: false,
+  ...overrides,
+})
+
+describe("UnifiedSearchForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders all four labeled inputs", () => {
+    render(<UnifiedSearchForm {...makeProps()} />)
+    expect(screen.getByLabelText(/provider name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/organization/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/npi number/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument()
+  })
+
+  it("renders the search and clear buttons", () => {
+    render(<UnifiedSearchForm {...makeProps()} />)
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it("disables the submit button when all fields are empty", () => {
+    render(<UnifiedSearchForm {...makeProps()} />)
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).toBeDisabled()
+  })
+
+  it("enables the submit button when providerName is filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "Smith",
+            organizationName: "",
+            npi: "",
+            location: "",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).not.toBeDisabled()
+  })
+
+  it("enables the submit button when organizationName is filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "",
+            organizationName: "General Hospital",
+            npi: "",
+            location: "",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).not.toBeDisabled()
+  })
+
+  it("enables the submit button when npi is filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "",
+            organizationName: "",
+            npi: "1234567894",
+            location: "",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).not.toBeDisabled()
+  })
+
+  it("keeps submit button disabled when only location is filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "",
+            organizationName: "",
+            npi: "",
+            location: "CA",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).toBeDisabled()
+  })
+
+  it("shows location hint alert when only location is filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "",
+            organizationName: "",
+            npi: "",
+            location: "CA",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.getByText(/please also enter a provider name/i),
+    ).toBeInTheDocument()
+  })
+
+  it("does not show location hint when location and providerName are both filled", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "Smith",
+            organizationName: "",
+            npi: "",
+            location: "CA",
+          },
+        })}
+      />,
+    )
+    expect(
+      screen.queryByText(/please also enter a provider name/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("calls onSearch with the current values on form submit", () => {
+    const onSearch = vi.fn()
+    const values = {
+      providerName: "Smith",
+      organizationName: "",
+      npi: "",
+      location: "",
+    }
+    render(<UnifiedSearchForm {...makeProps({ values, onSearch })} />)
+    fireEvent.submit(
+      screen
+        .getByRole("button", { name: /search providers/i })
+        .closest("form")!,
+    )
+    expect(onSearch).toHaveBeenCalledWith(values)
+  })
+
+  it("calls onClear when the Clear button is clicked", () => {
+    const onClear = vi.fn()
+    render(<UnifiedSearchForm {...makeProps({ onClear })} />)
+    fireEvent.click(screen.getByRole("button", { name: /clear/i }))
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables the submit button and shows 'Searching...' when isLoading is true", () => {
+    render(
+      <UnifiedSearchForm
+        {...makeProps({
+          values: {
+            providerName: "Smith",
+            organizationName: "",
+            npi: "",
+            location: "",
+          },
+          isLoading: true,
+        })}
+      />,
+    )
+    expect(screen.getByRole("button", { name: /searching/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/UnifiedSearchForm.tsx
+++ b/frontend/src/components/UnifiedSearchForm.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent, ChangeEvent } from "react"
-import { Button } from "@cmsgov/design-system"
+import { Alert, Button } from "@cmsgov/design-system"
 import { useTranslation } from "react-i18next"
 import styles from "./UnifiedSearchForm.module.css"
 
@@ -31,12 +31,12 @@ export const UnifiedSearchForm = ({
       onChange({ ...values, [field]: e.target.value })
     }
 
-  const hasAnyValue = !!(
+  const canSearch = !!(
     values.providerName ||
-    values.npi ||
-    values.location ||
-    values.organizationName
+    values.organizationName ||
+    values.npi
   )
+  const showLocationHint = !!values.location && !canSearch
 
   return (
     <form onSubmit={handleSubmit}>
@@ -104,6 +104,14 @@ export const UnifiedSearchForm = ({
         </div>
       </div>
 
+      {showLocationHint && (
+        <div className="ds-u-margin-top--2">
+          <Alert variation="warn" hideIcon>
+            {t("search.unified.locationHint")}
+          </Alert>
+        </div>
+      )}
+
       <div className="ds-l-row ds-u-margin-top--3">
         <div
           className={`ds-l-col--12 ds-u-display--flex ds-u-align-items--center ${styles.actionsRow}`}
@@ -111,7 +119,7 @@ export const UnifiedSearchForm = ({
           <Button
             type="submit"
             variation="solid"
-            disabled={!hasAnyValue || isLoading}
+            disabled={!canSearch || isLoading}
           >
             {isLoading
               ? t("search.searching")

--- a/frontend/src/components/UnifiedSearchForm.tsx
+++ b/frontend/src/components/UnifiedSearchForm.tsx
@@ -1,0 +1,132 @@
+import type { FormEvent, ChangeEvent } from "react"
+import { Button } from "@cmsgov/design-system"
+import { useTranslation } from "react-i18next"
+import styles from "./UnifiedSearchForm.module.css"
+
+type Props = {
+  values: UnifiedSearchParams
+  onChange: (values: UnifiedSearchParams) => void
+  onSearch: (values: UnifiedSearchParams) => void
+  onClear: () => void
+  isLoading?: boolean
+}
+
+export const UnifiedSearchForm = ({
+  values,
+  onChange,
+  onSearch,
+  onClear,
+  isLoading = false,
+}: Props) => {
+  const { t } = useTranslation()
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSearch(values)
+  }
+
+  const handleFieldChange =
+    (field: keyof UnifiedSearchParams) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onChange({ ...values, [field]: e.target.value })
+    }
+
+  const hasAnyValue = !!(
+    values.providerName ||
+    values.npi ||
+    values.location ||
+    values.organizationName
+  )
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="ds-l-row ds-u-margin-top--2">
+        <div className="ds-l-col--6">
+          <label className="ds-c-label" htmlFor="provider-name">
+            {t("search.unified.providerNameLabel")}
+          </label>
+          <input
+            className="ds-c-field"
+            type="text"
+            id="provider-name"
+            name="provider_name"
+            placeholder={t("search.unified.providerNamePlaceholder")}
+            value={values.providerName || ""}
+            onChange={handleFieldChange("providerName")}
+          />
+        </div>
+        <div className="ds-l-col--6">
+          <label className="ds-c-label" htmlFor="organization-name">
+            {t("search.unified.organizationLabel")}
+          </label>
+          <input
+            className="ds-c-field"
+            type="text"
+            id="organization-name"
+            name="organization_name"
+            placeholder={t("search.unified.organizationPlaceholder")}
+            value={values.organizationName || ""}
+            onChange={handleFieldChange("organizationName")}
+          />
+        </div>
+      </div>
+
+      <div className="ds-l-row ds-u-margin-top--2">
+        <div className="ds-l-col--6">
+          <label className="ds-c-label" htmlFor="npi-number">
+            {t("search.unified.npiLabel")}
+          </label>
+          <input
+            className="ds-c-field"
+            type="text"
+            id="npi-number"
+            name="npi"
+            placeholder={t("search.unified.npiPlaceholder")}
+            value={values.npi || ""}
+            onChange={handleFieldChange("npi")}
+            maxLength={10}
+            inputMode="numeric"
+          />
+        </div>
+        <div className="ds-l-col--6">
+          <label className="ds-c-label" htmlFor="location">
+            {t("search.unified.locationLabel")}
+          </label>
+          <input
+            className="ds-c-field"
+            type="text"
+            id="location"
+            name="location"
+            placeholder={t("search.unified.locationPlaceholder")}
+            value={values.location || ""}
+            onChange={handleFieldChange("location")}
+          />
+        </div>
+      </div>
+
+      <div className="ds-l-row ds-u-margin-top--3">
+        <div
+          className={`ds-l-col--12 ds-u-display--flex ds-u-align-items--center ${styles.actionsRow}`}
+        >
+          <Button
+            type="submit"
+            variation="solid"
+            disabled={!hasAnyValue || isLoading}
+          >
+            {isLoading
+              ? t("search.searching")
+              : t("search.unified.searchButton")}
+          </Button>
+          <Button
+            type="button"
+            variation="ghost"
+            onClick={onClear}
+            className={`ds-u-margin-left--2 ${styles.clearButton}`}
+          >
+            {t("search.unified.clearButton")}
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/i18n/en/search.json
+++ b/frontend/src/i18n/en/search.json
@@ -3,5 +3,27 @@
   "subtitle": "Search by name or NPI number to see the details of any practitioner or organization in the database.",
   "practitioner": "Practitioner search",
   "organization": "Organization search",
-  "searching": "Searching..."
+  "searching": "Searching...",
+  "unified": {
+    "title": "Search Providers",
+    "providerNameLabel": "Provider Name",
+    "providerNamePlaceholder": "Enter provider name",
+    "npiLabel": "NPI Number",
+    "npiPlaceholder": "Enter 10-digit NPI",
+    "locationLabel": "Location",
+    "locationPlaceholder": "City, State or ZIP code",
+    "organizationLabel": "Organization",
+    "organizationPlaceholder": "Hospital or organization name",
+    "searchButton": "Search Providers",
+    "clearButton": "Clear",
+    "viewFullProfile": "View Full Profile",
+    "noResults": "No results found. Try adjusting your search criteria.",
+    "resultsFound": "results found",
+    "initialPromptHeading": "Search",
+    "initialPrompt": "Use the form above to search for providers and organizations by name, NPI, location, or organization.",
+    "providerBadge": "Provider",
+    "organizationBadge": "Organization",
+    "crossEntityBadge": "Provider at Organization",
+    "unknownProvider": "Unknown Provider"
+  }
 }

--- a/frontend/src/i18n/en/search.json
+++ b/frontend/src/i18n/en/search.json
@@ -20,10 +20,11 @@
     "noResults": "No results found. Try adjusting your search criteria.",
     "resultsFound": "results found",
     "initialPromptHeading": "Search",
-    "initialPrompt": "Use the form above to search for providers and organizations by name, NPI, location, or organization.",
+    "initialPrompt": "Enter a provider name, organization name, or NPI number to search. Use the location field to refine your results.",
     "providerBadge": "Provider",
     "organizationBadge": "Organization",
     "crossEntityBadge": "Provider at Organization",
-    "unknownProvider": "Unknown Provider"
+    "unknownProvider": "Unknown Provider",
+    "locationHint": "Please also enter a provider name, organization name, or NPI number to search."
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -20,17 +20,10 @@ import { Landing } from "./pages/Landing"
 import { Layout } from "./pages/Layout"
 import { Login } from "./pages/Login"
 import { NotFound } from "./pages/NotFound.tsx"
-import {
-  Organization,
-  OrganizationSearch,
-} from "./pages/Organization"
-import { 
-  Practitioner,
-  PractitionerSearch
-} from "./pages/Practitioner"
-import { Search } from "./pages/Search"
+import { Organization, OrganizationSearch } from "./pages/Organization"
+import { Practitioner, PractitionerSearch } from "./pages/Practitioner"
+import { UnifiedSearch } from "./pages/Search"
 import { FrontendSettingsProvider } from "./state/FrontendSettingsProvider"
-
 
 const queryClient = new QueryClient()
 
@@ -49,7 +42,7 @@ createRoot(document.getElementById("root")!).render(
                   <Route path="/developers" element={<Developers />} />
 
                   <Route element={<FeatureFlagRoute name="SEARCH_APP" />}>
-                    <Route path="/search" element={<Search />} />
+                    <Route path="/search" element={<UnifiedSearch />} />
                     <Route path="/organizations">
                       <Route path="search" element={<OrganizationSearch />} />
                       <Route

--- a/frontend/src/pages/Organization/ListedOrganization.tsx
+++ b/frontend/src/pages/Organization/ListedOrganization.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router"
+import { FaHospital } from "react-icons/fa"
 import { OrganizationPresenter } from "../../presenters/OrganizationPresenter"
 import search from "../Search.module.css"
 import type { FHIROrganization } from "../../@types/fhir"
@@ -7,36 +8,50 @@ import type { FHIROrganization } from "../../@types/fhir"
 export const ListedOrganization = ({ data }: { data: FHIROrganization }) => {
   const { t } = useTranslation()
   const organization = new OrganizationPresenter(data)
+  const types = organization.types
+    .map((taxonomy) => taxonomy.display)
+    .slice(0, 5)
+    .join(", ")
 
   return (
     <div role="listitem" className="ds-u-border-top--1 ds-u-padding-y--2">
       <div className={search.entry}>
         <div className={search.head}>
+          <FaHospital className={search.icon} size={20} aria-hidden="true" />
+          <div className={search.titleBlock}>
+            <Link
+              className={search.name}
+              to={`/organizations/${data.id}`}
+              state={{ searchUrl: `/organizations/search${location.search}` }}
+            >
+              {organization.name}
+            </Link>
+          </div>
+        </div>
+        <div className={search.body}>
+          <div className={search.field}>
+            <div className={search.label}>{t("organizations.header.npi")}</div>
+            <div className={search.value}>{organization.npi || "---"}</div>
+          </div>
+          <div className={search.field}>
+            <div className={search.label}>
+              {t("organizations.listing.address")}
+            </div>
+            <div className={search.value}>{organization.address || "---"}</div>
+          </div>
+          <div className={search.field}>
+            <div className={search.label}>{t("organizations.about.type")}</div>
+            <div className={search.value}>{types || "---"}</div>
+          </div>
+        </div>
+        <div className={search.actions}>
           <Link
-            className={search.name}
+            className={search.actionButton}
             to={`/organizations/${data.id}`}
             state={{ searchUrl: `/organizations/search${location.search}` }}
           >
-            {organization.name}
+            {t("search.unified.viewFullProfile")}
           </Link>
-          <span>
-            <strong>NPI:</strong> {organization.npi}
-          </span>
-        </div>
-        <div className="ds-l-row">
-          <div className="ds-l-col--4 ds-m-col--6">
-            <strong>{t("organizations.listing.taxonomy")}</strong>
-            <br />
-            {organization.types.map(taxonomy => taxonomy.display).slice(0,5).join(", ") ?? "---"}
-          </div>
-          <div
-            className="ds-l-col--4 ds-m-col--6"
-            style={{ whiteSpace: "pre-line" }}
-          >
-            <strong>{t("organizations.listing.address")}</strong>
-            <br />
-            {organization.address}
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Practitioner/ListedPractitioner.tsx
+++ b/frontend/src/pages/Practitioner/ListedPractitioner.tsx
@@ -1,42 +1,156 @@
+import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router"
+import { FaUser } from "react-icons/fa"
 import search from "../Search.module.css"
 import { PractitionerPresenter } from "../../presenters/PractitionerPresenter"
 import type { FHIRPractitioner } from "../../@types/fhir"
+import { fetchPractitioner } from "../../state/requests/practitioners"
+import { fetchPractitionerRoles } from "../../state/requests/practitionerrole"
 
-export const ListedPractitioner = ({ data }: { data: FHIRPractitioner }) => {
+type Props = {
+  data: FHIRPractitioner
+  organizationName?: string
+  organizationId?: string | null
+  taxonomyText?: string
+  npiOverride?: string | null
+  searchUrl?: string
+}
+
+export const ListedPractitioner = ({
+  data,
+  organizationName,
+  organizationId,
+  taxonomyText,
+  npiOverride,
+  searchUrl,
+}: Props) => {
   const { t } = useTranslation()
-  const practitioner = new PractitionerPresenter(data)
+  const practitionerId = data.id ?? null
+  const initialPractitioner = new PractitionerPresenter(data)
+  const needsPractitionerDetails =
+    !!practitionerId &&
+    (!initialPractitioner.npi ||
+      !initialPractitioner.address ||
+      !initialPractitioner.phone ||
+      (!taxonomyText && initialPractitioner.taxonomy.length === 0))
+  const { data: hydratedPractitioner } = useQuery<FHIRPractitioner>({
+    queryKey: ["listed-practitioner", practitionerId],
+    queryFn: ({ signal }) => fetchPractitioner(practitionerId!, signal),
+    enabled: needsPractitionerDetails,
+  })
+  const effectivePractitionerData = hydratedPractitioner ?? data
+  const practitioner = new PractitionerPresenter(effectivePractitionerData)
+  const resolvedNpi = npiOverride ?? practitioner.npi
+  const taxonomy =
+    taxonomyText ??
+    practitioner.taxonomy
+      .map((item) => item.display)
+      .slice(0, 5)
+      .join(", ")
+  const { data: practitionerRoles } = useQuery({
+    queryKey: ["listed-practitioner-roles", resolvedNpi],
+    queryFn: ({ signal }) =>
+      fetchPractitionerRoles({
+        practitionerNPI: resolvedNpi ?? undefined,
+        signal,
+      }),
+    enabled: !!resolvedNpi && (!organizationName || !organizationId),
+  })
+  const roleOrganizations = Array.from(
+    new Map(
+      (practitionerRoles?.results.entry ?? [])
+        .map((entry) => entry?.resource.organization)
+        .filter(
+          (organization) =>
+            !!organization?.display && !!organization?.reference,
+        )
+        .map((organization) => [
+          organization!.reference,
+          {
+            id: organization!.reference.split("/").pop() ?? null,
+            name: organization!.display ?? "---",
+          },
+        ]),
+    ).values(),
+  )
+  const resolvedOrganizationId =
+    organizationId ?? roleOrganizations[0]?.id ?? null
+  const resolvedOrganizationName =
+    organizationName ?? roleOrganizations[0]?.name
+  const detailUrl = practitionerId ? `/practitioners/${practitionerId}` : null
+  const backLink = searchUrl ?? `/practitioners/search${location.search}`
 
   return (
     <div role="listitem" className="ds-u-border-top--1 ds-u-padding-y--2">
       <div className={search.entry}>
         <div className={search.head}>
-          <Link
-            className={search.name}
-            to={`/practitioners/${data.id}`}
-            state={{ searchUrl: `/practitioners/search${location.search}` }}
-          >
-            {practitioner.names[0]}
-          </Link>
-          <span>
-            <strong>NPI:</strong> {practitioner.npi}
-          </span>
+          <FaUser className={search.icon} size={18} aria-hidden="true" />
+          <div className={search.titleBlock}>
+            {detailUrl ? (
+              <Link
+                className={search.name}
+                to={detailUrl}
+                state={{ searchUrl: backLink }}
+              >
+                {practitioner.names[0]}
+              </Link>
+            ) : (
+              <span className={search.name}>{practitioner.names[0]}</span>
+            )}
+          </div>
         </div>
-        <div className="ds-l-row">
-          <div className="ds-l-col--4 ds-m-col--6">
-            <strong>{t("practitioners.listing.taxonomy")}</strong>
-            <br />
-            {practitioner.taxonomy.map(taxonomy => taxonomy.display).slice(0,5).join(", ") ?? "---"}
+        <div className={search.body}>
+          <div className={search.field}>
+            <div className={search.label}>{t("practitioners.npi")}</div>
+            <div className={search.value}>{resolvedNpi ?? "---"}</div>
           </div>
-          <div
-            className="ds-l-col--4 ds-m-col--6"
-            style={{ whiteSpace: "pre-line " }}
-          >
-            <strong>{t("practitioners.listing.address")}</strong>
-            <br />
-            {practitioner.address}
+          <div className={search.field}>
+            <div className={search.label}>
+              {t("search.unified.organizationLabel")}
+            </div>
+            <div className={search.value}>
+              {resolvedOrganizationId ? (
+                <Link
+                  to={`/organizations/${resolvedOrganizationId}`}
+                  state={{ searchUrl: backLink }}
+                >
+                  {resolvedOrganizationName ?? "---"}
+                </Link>
+              ) : (
+                (resolvedOrganizationName ?? "---")
+              )}
+            </div>
           </div>
+          <div className={search.field}>
+            <div className={search.label}>
+              {t("practitioners.listing.address")}
+            </div>
+            <div className={search.value}>{practitioner.address || "---"}</div>
+          </div>
+          <div className={search.field}>
+            <div className={search.label}>
+              {t("practitioners.detail.contact.phone")}
+            </div>
+            <div className={search.value}>{practitioner.phone || "---"}</div>
+          </div>
+          <div className={search.field}>
+            <div className={search.label}>
+              {t("practitioners.listing.taxonomy")}
+            </div>
+            <div className={search.value}>{taxonomy || "---"}</div>
+          </div>
+        </div>
+        <div className={search.actions}>
+          {detailUrl && (
+            <Link
+              className={search.actionButton}
+              to={detailUrl}
+              state={{ searchUrl: backLink }}
+            >
+              {t("search.unified.viewFullProfile")}
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Search.module.css
+++ b/frontend/src/pages/Search.module.css
@@ -1,20 +1,98 @@
 .entry {
-  & .name {
-    color: #1e3c70;
-
-    font-family: var(--theme-font-family-body, "Open Sans");
-    font-size: var(--theme-font-size-lg, 1.5rem);
-    font-style: normal;
-    font-weight: var(--theme-font-weight-heading-md, 700);
-    line-height: 130%; /* 1.3rem */
-
-    text-decoration: none;
-  }
+  border: 1px solid var(--color-base-lighter);
+  border-radius: 0.5rem;
+  background: var(--color-white);
+  padding: 1.25rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 
   & .head {
     display: flex;
-    align-items: bottom;
-    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  & .titleBlock {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  & .icon {
+    flex: 0 0 auto;
+    color: var(--color-primary);
+  }
+
+  & .name {
+    color: #1e3c70;
+    font-family: var(--theme-font-family-body, "Open Sans");
+    font-size: 1.375rem;
+    font-weight: var(--theme-font-weight-heading-md, 700);
+    line-height: 1.3;
+    text-decoration: none;
+  }
+
+  & .name:hover {
+    text-decoration: underline;
+  }
+
+  & .body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 2rem;
+  }
+
+  & .field {
+    min-width: 0;
+  }
+
+  & .label {
+    margin-bottom: 0.25rem;
+    color: var(--color-base);
+    font-family: var(--theme-font-family-body, "Open Sans");
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1.4;
+  }
+
+  & .value {
+    color: var(--color-base-darkest);
+    font-family: var(--theme-font-family-body, "Open Sans");
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    white-space: pre-line;
+    word-break: break-word;
+  }
+
+  & .actions {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-base-lighter);
+  }
+
+  & .actionButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.5rem;
+    padding: 0.625rem 1rem;
+    border-radius: 0.25rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    font-family: var(--theme-font-family-body, "Open Sans");
+    font-size: 0.9375rem;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+  }
+
+  & .actionButton:hover,
+  & .actionButton:focus {
+    background: var(--color-primary-dark);
+    color: var(--color-white);
+    text-decoration: none;
   }
 }
 

--- a/frontend/src/pages/Search/UnifiedSearch.test.tsx
+++ b/frontend/src/pages/Search/UnifiedSearch.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router"
+import { describe, expect, it, beforeEach } from "vitest"
+import { render } from "../../../tests/render"
+import { mockGlobalFetch } from "../../../tests/mockGlobalFetch"
+import { UnifiedSearch } from "./UnifiedSearch"
+
+const RoutedUnifiedSearch = () => (
+  <MemoryRouter initialEntries={["/search"]}>
+    <Routes>
+      <Route path="/search" element={<UnifiedSearch />} />
+    </Routes>
+  </MemoryRouter>
+)
+
+describe("UnifiedSearch", () => {
+  beforeEach(() => {
+    mockGlobalFetch()
+  })
+
+  it("renders the page title", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(
+      screen.getByRole("heading", { name: "Search Providers" }),
+    ).toBeInTheDocument()
+  })
+
+  it("renders all four form inputs", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(screen.getByLabelText(/provider name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/organization/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/npi number/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument()
+  })
+
+  it("renders the submit button in disabled state initially", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(
+      screen.getByRole("button", { name: /search providers/i }),
+    ).toBeDisabled()
+  })
+
+  it("renders the Clear button", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it("shows the initial prompt alert when no search has been submitted", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(
+      screen.getByRole("heading", { name: /^search$/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("does not show search results before a search is submitted", () => {
+    render(<RoutedUnifiedSearch />)
+    expect(screen.queryByTestId("searchresults")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Search/UnifiedSearch.tsx
+++ b/frontend/src/pages/Search/UnifiedSearch.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react"
+import { useSearchParams } from "react-router"
+import classNames from "classnames"
+import { useTranslation } from "react-i18next"
+import { FaSearch } from "react-icons/fa"
+import { TitlePanel } from "../../components/TitlePanel"
+import { UnifiedSearchForm } from "../../components/UnifiedSearchForm"
+import { UnifiedSearchResults } from "./UnifiedSearchResults"
+import { useUnifiedSearchAPI } from "../../state/requests/unifiedSearch"
+import layout from "../Layout.module.css"
+
+const readSearchParams = (search: URLSearchParams): UnifiedSearchParams => ({
+  providerName: search.get("provider_name") || undefined,
+  npi: search.get("npi") || undefined,
+  location: search.get("location") || undefined,
+  organizationName: search.get("organization_name") || undefined,
+})
+
+const toURLParams = (
+  params: UnifiedSearchParams,
+  page: number,
+): Record<string, string> => {
+  const out: Record<string, string> = {}
+  if (params.providerName) out.provider_name = params.providerName
+  if (params.npi) out.npi = params.npi
+  if (params.location) out.location = params.location
+  if (params.organizationName) out.organization_name = params.organizationName
+  out.page = page.toString()
+  return out
+}
+
+export const UnifiedSearch = () => {
+  const { t } = useTranslation()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const contentClass = classNames(layout.content, "ds-l-container")
+
+  const committedParams = readSearchParams(searchParams)
+  const currentPage = parseInt(searchParams.get("page") || "1", 10) || 1
+
+  const [formValues, setFormValues] = useState<UnifiedSearchParams>({
+    providerName: committedParams.providerName || "",
+    npi: committedParams.npi || "",
+    location: committedParams.location || "",
+    organizationName: committedParams.organizationName || "",
+  })
+
+  const {
+    practitioners,
+    organizations,
+    practitionerRoles,
+    searchMode,
+    isLoading,
+    isPlaceholderData,
+    error,
+    hasSearch,
+  } = useUnifiedSearchAPI(committedParams, { page: currentPage, page_size: 10 })
+
+  const handleSearch = (values: UnifiedSearchParams) => {
+    setSearchParams(toURLParams(values, 1), { preventScrollReset: true })
+  }
+
+  const handleClear = () => {
+    setFormValues({
+      providerName: "",
+      npi: "",
+      location: "",
+      organizationName: "",
+    })
+    setSearchParams({})
+  }
+
+  const handlePageChange = (page: number) => {
+    setSearchParams(toURLParams(committedParams, page), {
+      preventScrollReset: true,
+    })
+  }
+
+  return (
+    <>
+      <TitlePanel
+        icon={<FaSearch size={42} aria-hidden="true" />}
+        title={t("search.unified.title")}
+        color="var(--color-primary-darkest)"
+        className={layout.compactLeader}
+      >
+        <UnifiedSearchForm
+          values={formValues}
+          onChange={setFormValues}
+          onSearch={handleSearch}
+          onClear={handleClear}
+          isLoading={isLoading}
+        />
+      </TitlePanel>
+
+      <main className={contentClass}>
+        <div className="ds-l-row">
+          <div className="ds-l-col--12 ds-u-margin-bottom--7">
+            <UnifiedSearchResults
+              practitioners={practitioners}
+              organizations={organizations}
+              practitionerRoles={practitionerRoles}
+              searchMode={searchMode}
+              isLoading={isLoading}
+              isPlaceholderData={isPlaceholderData}
+              hasSearch={hasSearch}
+              error={error}
+              page={currentPage}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/frontend/src/pages/Search/UnifiedSearchResults.tsx
+++ b/frontend/src/pages/Search/UnifiedSearchResults.tsx
@@ -44,6 +44,24 @@ const buildResultItems = (
     return items
   }
 
+  if (searchMode === "npi-lookup") {
+    const hasPractitioner = (practitioners?.results?.entry?.length ?? 0) > 0
+    const hasOrganization = (organizations?.results?.entry?.length ?? 0) > 0
+
+    if (hasPractitioner && practitioners?.results?.entry) {
+      for (const entry of practitioners.results.entry) {
+        if (entry?.resource)
+          items.push({ type: "provider", data: entry.resource })
+      }
+    } else if (hasOrganization && organizations?.results?.entry) {
+      for (const entry of organizations.results.entry) {
+        if (entry?.resource)
+          items.push({ type: "organization", data: entry.resource })
+      }
+    }
+    return items
+  }
+
   if (practitioners?.results?.entry) {
     for (const entry of practitioners.results.entry) {
       if (entry?.resource)
@@ -66,6 +84,10 @@ const getTotalCount = (
   searchMode: SearchMode,
 ): number => {
   if (searchMode === "cross-entity") return practitionerRoles?.count ?? 0
+  if (searchMode === "npi-lookup") {
+    const practCount = practitioners?.count ?? 0
+    return practCount > 0 ? practCount : (organizations?.count ?? 0)
+  }
   return (practitioners?.count ?? 0) + (organizations?.count ?? 0)
 }
 
@@ -79,6 +101,9 @@ const getTotalPages = (
   let maxCount: number
   if (searchMode === "cross-entity") {
     maxCount = practitionerRoles?.count ?? 0
+  } else if (searchMode === "npi-lookup") {
+    const practCount = practitioners?.count ?? 0
+    maxCount = practCount > 0 ? practCount : (organizations?.count ?? 0)
   } else {
     maxCount = Math.max(practitioners?.count ?? 0, organizations?.count ?? 0)
   }

--- a/frontend/src/pages/Search/UnifiedSearchResults.tsx
+++ b/frontend/src/pages/Search/UnifiedSearchResults.tsx
@@ -1,0 +1,248 @@
+import { Alert, Pagination } from "@cmsgov/design-system"
+import { useTranslation } from "react-i18next"
+import type {
+  FHIRCollection,
+  FHIRPractitioner,
+  FHIROrganization,
+  FHIRPractitionerRole,
+} from "../../@types/fhir"
+import { ListedPractitioner } from "../Practitioner/ListedPractitioner"
+import { ListedOrganization } from "../Organization/ListedOrganization"
+import { NpdMarkdown } from "../../components/markdown/NpdMarkdown"
+import type { SearchMode } from "../../state/requests/unifiedSearch"
+
+type ResultItem =
+  | { type: "provider"; data: FHIRPractitioner }
+  | { type: "organization"; data: FHIROrganization }
+  | { type: "role"; data: FHIRPractitionerRole }
+
+type Props = {
+  practitioners: FHIRCollection<FHIRPractitioner> | undefined
+  organizations: FHIRCollection<FHIROrganization> | undefined
+  practitionerRoles: FHIRCollection<FHIRPractitionerRole> | undefined
+  searchMode: SearchMode
+  isLoading: boolean
+  isPlaceholderData: boolean
+  hasSearch: boolean
+  error: Error | null
+  page: number
+  onPageChange: (page: number) => void
+}
+
+const buildResultItems = (
+  practitioners: FHIRCollection<FHIRPractitioner> | undefined,
+  organizations: FHIRCollection<FHIROrganization> | undefined,
+  practitionerRoles: FHIRCollection<FHIRPractitionerRole> | undefined,
+  searchMode: SearchMode,
+): ResultItem[] => {
+  const items: ResultItem[] = []
+
+  if (searchMode === "cross-entity" && practitionerRoles?.results?.entry) {
+    for (const entry of practitionerRoles.results.entry) {
+      if (entry?.resource) items.push({ type: "role", data: entry.resource })
+    }
+    return items
+  }
+
+  if (practitioners?.results?.entry) {
+    for (const entry of practitioners.results.entry) {
+      if (entry?.resource)
+        items.push({ type: "provider", data: entry.resource })
+    }
+  }
+  if (organizations?.results?.entry) {
+    for (const entry of organizations.results.entry) {
+      if (entry?.resource)
+        items.push({ type: "organization", data: entry.resource })
+    }
+  }
+  return items
+}
+
+const getTotalCount = (
+  practitioners: FHIRCollection<FHIRPractitioner> | undefined,
+  organizations: FHIRCollection<FHIROrganization> | undefined,
+  practitionerRoles: FHIRCollection<FHIRPractitionerRole> | undefined,
+  searchMode: SearchMode,
+): number => {
+  if (searchMode === "cross-entity") return practitionerRoles?.count ?? 0
+  return (practitioners?.count ?? 0) + (organizations?.count ?? 0)
+}
+
+const getTotalPages = (
+  practitioners: FHIRCollection<FHIRPractitioner> | undefined,
+  organizations: FHIRCollection<FHIROrganization> | undefined,
+  practitionerRoles: FHIRCollection<FHIRPractitionerRole> | undefined,
+  searchMode: SearchMode,
+  pageSize: number,
+): number => {
+  let maxCount: number
+  if (searchMode === "cross-entity") {
+    maxCount = practitionerRoles?.count ?? 0
+  } else {
+    maxCount = Math.max(practitioners?.count ?? 0, organizations?.count ?? 0)
+  }
+  return Math.max(1, Math.ceil(maxCount / pageSize))
+}
+
+const extractId = (reference?: string | null): string | null =>
+  reference?.split("/").pop() ?? null
+
+const getRoleTaxonomyDisplay = (
+  role: FHIRPractitionerRole,
+): string | undefined => {
+  const first = role.specialty?.[0]
+  if (!first) return undefined
+  return first.text || first.coding?.[0]?.display || undefined
+}
+
+export const UnifiedSearchResults = ({
+  practitioners,
+  organizations,
+  practitionerRoles,
+  searchMode,
+  isLoading,
+  isPlaceholderData,
+  hasSearch,
+  error,
+  page,
+  onPageChange,
+}: Props) => {
+  const { t } = useTranslation()
+  const combinedItems = buildResultItems(
+    practitioners,
+    organizations,
+    practitionerRoles,
+    searchMode,
+  )
+  const totalCount = getTotalCount(
+    practitioners,
+    organizations,
+    practitionerRoles,
+    searchMode,
+  )
+  const totalPages = getTotalPages(
+    practitioners,
+    organizations,
+    practitionerRoles,
+    searchMode,
+    10,
+  )
+  const hasResults = combinedItems.length > 0
+
+  if (error) {
+    return (
+      <div className="ds-u-margin-top--4">
+        <Alert variation="error" heading="Error">
+          {error instanceof Error
+            ? error.message
+            : "An error occurred during search"}
+        </Alert>
+      </div>
+    )
+  }
+
+  if (!hasSearch) {
+    return (
+      <div className="ds-u-margin-top--4">
+        <Alert heading={t("search.unified.initialPromptHeading")}>
+          <NpdMarkdown content={t("search.unified.initialPrompt")} />
+        </Alert>
+      </div>
+    )
+  }
+
+  if (isLoading && !isPlaceholderData) {
+    return null
+  }
+
+  if (!hasResults) {
+    return (
+      <div className="ds-u-margin-top--4">
+        <p>{t("search.unified.noResults")}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="ds-u-margin-top--4">
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "1rem",
+        }}
+      >
+        <p className="ds-u-margin--0">
+          <strong>{totalCount}</strong> {t("search.unified.resultsFound")}
+        </p>
+      </div>
+
+      {totalPages > 1 && (
+        <div style={{ pointerEvents: isPlaceholderData ? "none" : "auto" }}>
+          <Pagination
+            currentPage={page}
+            onPageChange={(evt, nextPage) => {
+              evt.preventDefault()
+              evt.stopPropagation()
+              onPageChange(nextPage)
+            }}
+            renderHref={(pageNumber) => {
+              const params = new URLSearchParams(window.location.search)
+              params.set("page", pageNumber.toString())
+              return `?${params.toString()}`
+            }}
+            totalPages={totalPages}
+          />
+        </div>
+      )}
+
+      <div
+        data-testid="searchresults"
+        role="list"
+        style={{
+          opacity: isPlaceholderData ? 0.5 : 1,
+          transition: "opacity 200ms ease",
+          pointerEvents: isPlaceholderData ? "none" : "auto",
+        }}
+      >
+        {combinedItems.map((item) => {
+          const key = `${item.type}-${item.data.id}`
+          return (
+            <div key={key}>
+              {item.type === "provider" && (
+                <ListedPractitioner data={item.data} />
+              )}
+              {item.type === "organization" && (
+                <ListedOrganization data={item.data} />
+              )}
+              {item.type === "role" && (
+                <ListedPractitioner
+                  data={
+                    {
+                      id: extractId(item.data.practitioner?.reference),
+                      name: [
+                        {
+                          text:
+                            item.data.practitioner?.display ??
+                            t("search.unified.unknownProvider"),
+                        },
+                      ],
+                    } as FHIRPractitioner
+                  }
+                  organizationName={
+                    item.data.organization?.display ?? undefined
+                  }
+                  organizationId={extractId(item.data.organization?.reference)}
+                  taxonomyText={getRoleTaxonomyDisplay(item.data)}
+                  searchUrl={`/search${location.search}`}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Search/index.ts
+++ b/frontend/src/pages/Search/index.ts
@@ -1,1 +1,2 @@
 export { Search } from "./Search"
+export { UnifiedSearch } from "./UnifiedSearch"

--- a/frontend/src/presenters/PractitionerPresenter.ts
+++ b/frontend/src/presenters/PractitionerPresenter.ts
@@ -1,5 +1,8 @@
 import type { FHIRPractitioner, FHIRReference } from "../@types/fhir"
-import type { OrganizationDetails, PractitionerDetailsType } from "../state/requests/practitioners"
+import type {
+  OrganizationDetails,
+  PractitionerDetailsType,
+} from "../state/requests/practitioners"
 import {
   formatAddress,
   formatDetails,
@@ -9,16 +12,20 @@ import type { LogicalIdOfThisArtifact } from "../@types/fhir/Endpoint"
 
 export class PractitionerPresenter {
   private record: FHIRPractitioner
-  constructor(record: FHIRPractitioner) {this.record = record}
+  constructor(record: FHIRPractitioner) {
+    this.record = record
+  }
 
-  get names(): Array<string | undefined | null>  {
+  get names(): Array<string | undefined | null> {
     const names = this.record.name
-    return names?.map(name => name.text) || []
+    return names?.map((name) => name.text) || []
   }
 
   get npi(): string | null {
     const npiIdentifier = this.record.identifier?.find(
-      (id) => id.system === "http://terminology.hl7.org/NamingSystem/npi",
+      (id) =>
+        id.system === "http://terminology.hl7.org/NamingSystem/npi" ||
+        id.system === "http://hl7.org/fhir/sid/us-npi",
     )
     return npiIdentifier?.value ?? null
   }
@@ -56,7 +63,10 @@ export class PractitionerPresenter {
     return this.record.identifier.map((identity) => ({
       type: formatOtherIdentifierType(identity.type?.coding?.[0]?.code),
       number: identity.value,
-      details: identity.period || identity.assigner ? formatDetails(identity.period, identity.assigner?.display) : "",
+      details:
+        identity.period || identity.assigner
+          ? formatDetails(identity.period, identity.assigner?.display)
+          : "",
     }))
   }
 
@@ -70,76 +80,93 @@ export class PractitionerPresenter {
       nuccCode: taxonomy.code?.coding?.[0]?.code ?? "",
     }))
   }
-
-  
 }
 
 export class FullPractitionerPresenter {
   private record: PractitionerDetailsType
-  constructor(record: PractitionerDetailsType) {this.record = record}
+  constructor(record: PractitionerDetailsType) {
+    this.record = record
+  }
   get organizations() {
     if (!this.record.practitionerRoleData?.results?.entry?.length) return []
-    const organizationDetailData: OrganizationDetails = {};
+    const organizationDetailData: OrganizationDetails = {}
     this.record.practitionerRoleData.results.entry.forEach((role) => {
-      const organizationId = role?.resource.organization.reference.split('/').pop();
-      const locationId = role?.resource.location[0].reference.split('/').pop();
-      const endpointIds = role?.resource.endpoint?.map((endpoint: FHIRReference) => { return endpoint.reference.split('/').pop()});
-      if (organizationId && Object.keys(organizationDetailData).includes(organizationId)) {
-        const existingEndpointIds: Array<string | undefined> = organizationDetailData[organizationId].endpoints?.map((endpoint) => endpoint?.id )
-        endpointIds?.forEach( (endpointId) => {
+      const organizationId = role?.resource.organization.reference
+        .split("/")
+        .pop()
+      const locationId = role?.resource.location[0].reference.split("/").pop()
+      const endpointIds = role?.resource.endpoint?.map(
+        (endpoint: FHIRReference) => {
+          return endpoint.reference.split("/").pop()
+        },
+      )
+      if (
+        organizationId &&
+        Object.keys(organizationDetailData).includes(organizationId)
+      ) {
+        const existingEndpointIds: Array<string | undefined> =
+          organizationDetailData[organizationId].endpoints?.map(
+            (endpoint) => endpoint?.id,
+          )
+        endpointIds?.forEach((endpointId) => {
           if (endpointId && !existingEndpointIds.includes(endpointId)) {
             const endpoint = this.record.endpointData[endpointId]
             const endpointRecord = {
               id: endpoint.id,
               address: endpoint.address,
-              connectionType: endpoint.connectionType.display
+              connectionType: endpoint.connectionType.display,
             }
-            organizationDetailData[organizationId].endpoints.push(endpointRecord)
+            organizationDetailData[organizationId].endpoints.push(
+              endpointRecord,
+            )
           }
         })
-        const existingLocationIds: Array<LogicalIdOfThisArtifact | undefined> = organizationDetailData[organizationId].locations.map((location) => location.id)
+        const existingLocationIds: Array<LogicalIdOfThisArtifact | undefined> =
+          organizationDetailData[organizationId].locations.map(
+            (location) => location.id,
+          )
         if (locationId && !existingLocationIds.includes(locationId)) {
           const loc = this.record.locationData[locationId]
           const locRecord = {
             id: loc.id,
             name: loc.name,
             address: formatAddress(loc.address, false),
-            contact: loc.telecom
+            contact: loc.telecom,
           }
           organizationDetailData[organizationId].locations.push(locRecord)
         }
-      }
-      else {
-        if (organizationId && locationId){
+      } else {
+        if (organizationId && locationId) {
           const loc = this.record.locationData[locationId]
           const locRecord = {
             id: loc.id,
             name: loc.name,
             address: formatAddress(loc.address, false),
-            contact: loc.telecom
+            contact: loc.telecom,
           }
           organizationDetailData[organizationId] = {
             organization: this.record.organizationData[organizationId],
-            endpoints: endpointIds?.map((endpointId) => {
-              if (endpointId) {
-                const endpoint = this.record.endpointData[endpointId]
-                const endpointRecord = {
-                  id: endpoint.id,
-                  address: endpoint.address,
-                  connectionType: endpoint.connectionType.display
+            endpoints:
+              endpointIds?.map((endpointId) => {
+                if (endpointId) {
+                  const endpoint = this.record.endpointData[endpointId]
+                  const endpointRecord = {
+                    id: endpoint.id,
+                    address: endpoint.address,
+                    connectionType: endpoint.connectionType.display,
+                  }
+                  return endpointRecord
                 }
-                return endpointRecord
-              }
-            }) ?? [],
+              }) ?? [],
             locations: [locRecord],
-            roleDetails: role?.resource
-          };
+            roleDetails: role?.resource,
+          }
         }
       }
     })
 
-  return {
-    ...organizationDetailData
-  }
+    return {
+      ...organizationDetailData,
+    }
   }
 }

--- a/frontend/src/state/requests/searchAdapters.ts
+++ b/frontend/src/state/requests/searchAdapters.ts
@@ -1,0 +1,144 @@
+import type {
+  FHIRCollection,
+  FHIRPractitioner,
+  FHIROrganization,
+  FHIRPractitionerRole,
+} from "../../@types/fhir"
+import { apiUrl } from "../api"
+
+export interface SearchAdapter {
+  searchProviders(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIRPractitioner>>
+
+  searchOrganizations(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIROrganization>>
+
+  searchCrossEntity(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIRPractitionerRole>>
+}
+
+const parseLocationParam = (location: string, url: URL, prefix = "") => {
+  const trimmed = location.trim()
+  if (/^\d{5}$/.test(trimmed)) {
+    url.searchParams.set(`${prefix}address_postalcode`, trimmed)
+  } else if (/^[A-Za-z]{2}$/.test(trimmed)) {
+    url.searchParams.set(`${prefix}address_state`, trimmed.toUpperCase())
+  } else {
+    url.searchParams.set(`${prefix}address`, trimmed)
+  }
+}
+
+export class FastAPISearchAdapter implements SearchAdapter {
+  async searchProviders(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIRPractitioner>> {
+    const url = new URL(apiUrl("/fhir/Practitioner/"))
+
+    if (pagination.page) {
+      url.searchParams.set("page", pagination.page.toString())
+    }
+    if (pagination.page_size) {
+      url.searchParams.set("page_size", pagination.page_size.toString())
+    }
+    if (pagination.sort) {
+      url.searchParams.set("_sort", pagination.sort)
+    }
+
+    if (params.providerName) {
+      url.searchParams.set("name", params.providerName)
+    }
+    if (params.npi) {
+      url.searchParams.set("identifier", params.npi)
+    }
+    if (params.location) {
+      parseLocationParam(params.location, url)
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.error(await response.text())
+      return Promise.reject(`error in ${url} request`)
+    }
+    return response.json()
+  }
+
+  async searchOrganizations(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIROrganization>> {
+    const url = new URL(apiUrl("/fhir/Organization/"))
+
+    if (pagination.page) {
+      url.searchParams.set("page", pagination.page.toString())
+    }
+    if (pagination.page_size) {
+      url.searchParams.set("page_size", pagination.page_size.toString())
+    }
+    if (pagination.sort) {
+      url.searchParams.set("_sort", pagination.sort)
+    }
+
+    if (params.organizationName) {
+      url.searchParams.set("name", params.organizationName)
+    }
+    if (params.npi) {
+      url.searchParams.set("identifier", `NPI|${params.npi}`)
+    }
+    if (params.location) {
+      parseLocationParam(params.location, url)
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.error(await response.text())
+      return Promise.reject(`error in ${url} request`)
+    }
+    return response.json()
+  }
+
+  async searchCrossEntity(
+    params: UnifiedSearchParams,
+    pagination: PaginationParams & { sort?: string },
+  ): Promise<FHIRCollection<FHIRPractitionerRole>> {
+    const url = new URL(apiUrl("/fhir/PractitionerRole/"))
+
+    if (pagination.page) {
+      url.searchParams.set("page", pagination.page.toString())
+    }
+    if (pagination.page_size) {
+      url.searchParams.set("page_size", pagination.page_size.toString())
+    }
+    if (pagination.sort) {
+      url.searchParams.set("_sort", pagination.sort)
+    }
+
+    if (params.providerName) {
+      url.searchParams.set("practitioner_name", params.providerName)
+    }
+    if (params.npi) {
+      url.searchParams.set("practitioner_identifier", `NPI|${params.npi}`)
+    }
+    if (params.organizationName) {
+      url.searchParams.set("organization_name", params.organizationName)
+    }
+    if (params.location) {
+      parseLocationParam(params.location, url, "location_")
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.error(await response.text())
+      return Promise.reject(`error in ${url} request`)
+    }
+    return response.json()
+  }
+}
+
+export const defaultAdapter = new FastAPISearchAdapter()

--- a/frontend/src/state/requests/unifiedSearch.test.ts
+++ b/frontend/src/state/requests/unifiedSearch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { getSearchMode } from "./unifiedSearch"
+
+describe("getSearchMode", () => {
+  it("returns 'none' when all params are empty", () => {
+    expect(getSearchMode({})).toBe("none")
+  })
+
+  it("returns 'none' when all params are undefined", () => {
+    expect(
+      getSearchMode({
+        providerName: undefined,
+        organizationName: undefined,
+        npi: undefined,
+        location: undefined,
+      }),
+    ).toBe("none")
+  })
+
+  it("returns 'providers' when only providerName is set", () => {
+    expect(getSearchMode({ providerName: "Smith" })).toBe("providers")
+  })
+
+  it("returns 'organizations' when only organizationName is set", () => {
+    expect(getSearchMode({ organizationName: "General Hospital" })).toBe(
+      "organizations",
+    )
+  })
+
+  it("returns 'npi-lookup' when only npi is set", () => {
+    expect(getSearchMode({ npi: "1234567894" })).toBe("npi-lookup")
+  })
+
+  it("returns 'cross-entity' when both providerName and organizationName are set", () => {
+    expect(
+      getSearchMode({
+        providerName: "Smith",
+        organizationName: "General Hospital",
+      }),
+    ).toBe("cross-entity")
+  })
+
+  it("returns 'providers' when providerName and location are set", () => {
+    expect(getSearchMode({ providerName: "Smith", location: "CA" })).toBe(
+      "providers",
+    )
+  })
+
+  it("returns 'npi-lookup' when npi and location are set", () => {
+    expect(getSearchMode({ npi: "1234567894", location: "12345" })).toBe(
+      "npi-lookup",
+    )
+  })
+
+  it("returns 'cross-entity' when providerName, organizationName, and npi are all set", () => {
+    expect(
+      getSearchMode({
+        providerName: "Smith",
+        organizationName: "General Hospital",
+        npi: "1234567894",
+      }),
+    ).toBe("cross-entity")
+  })
+})

--- a/frontend/src/state/requests/unifiedSearch.ts
+++ b/frontend/src/state/requests/unifiedSearch.ts
@@ -11,7 +11,7 @@ export type SearchMode =
   | "providers"
   | "organizations"
   | "cross-entity"
-  | "both"
+  | "npi-lookup"
   | "none"
 
 interface UseUnifiedSearchOptions {
@@ -21,13 +21,13 @@ interface UseUnifiedSearchOptions {
 export const getSearchMode = (params: UnifiedSearchParams): SearchMode => {
   const hasProviderFields = !!params.providerName
   const hasOrgFields = !!params.organizationName
-  const hasAmbiguousFields = !!(params.npi || params.location)
+  const hasNpi = !!params.npi
 
-  if (!hasProviderFields && !hasOrgFields && !hasAmbiguousFields) return "none"
   if (hasProviderFields && hasOrgFields) return "cross-entity"
   if (hasProviderFields) return "providers"
   if (hasOrgFields) return "organizations"
-  return "both"
+  if (hasNpi) return "npi-lookup"
+  return "none"
 }
 
 export const useUnifiedSearchAPI = (
@@ -51,7 +51,7 @@ export const useUnifiedSearchAPI = (
           pagination.sort,
         ],
         queryFn:
-          searchMode === "providers" || searchMode === "both"
+          searchMode === "providers" || searchMode === "npi-lookup"
             ? () => adapter.searchProviders(searchParams, pagination)
             : skipToken,
         placeholderData: keepPreviousData,
@@ -66,7 +66,7 @@ export const useUnifiedSearchAPI = (
           pagination.sort,
         ],
         queryFn:
-          searchMode === "organizations" || searchMode === "both"
+          searchMode === "organizations" || searchMode === "npi-lookup"
             ? () => adapter.searchOrganizations(searchParams, pagination)
             : skipToken,
         placeholderData: keepPreviousData,

--- a/frontend/src/state/requests/unifiedSearch.ts
+++ b/frontend/src/state/requests/unifiedSearch.ts
@@ -1,0 +1,120 @@
+import { useQueries, keepPreviousData, skipToken } from "@tanstack/react-query"
+import type {
+  FHIRCollection,
+  FHIRPractitioner,
+  FHIROrganization,
+  FHIRPractitionerRole,
+} from "../../@types/fhir"
+import { defaultAdapter, type SearchAdapter } from "./searchAdapters"
+
+export type SearchMode =
+  | "providers"
+  | "organizations"
+  | "cross-entity"
+  | "both"
+  | "none"
+
+interface UseUnifiedSearchOptions {
+  adapter?: SearchAdapter
+}
+
+export const getSearchMode = (params: UnifiedSearchParams): SearchMode => {
+  const hasProviderFields = !!params.providerName
+  const hasOrgFields = !!params.organizationName
+  const hasAmbiguousFields = !!(params.npi || params.location)
+
+  if (!hasProviderFields && !hasOrgFields && !hasAmbiguousFields) return "none"
+  if (hasProviderFields && hasOrgFields) return "cross-entity"
+  if (hasProviderFields) return "providers"
+  if (hasOrgFields) return "organizations"
+  return "both"
+}
+
+export const useUnifiedSearchAPI = (
+  searchParams: UnifiedSearchParams,
+  pagination: PaginationParams & { sort?: string },
+  options?: UseUnifiedSearchOptions,
+) => {
+  const adapter = options?.adapter ?? defaultAdapter
+  const searchMode = getSearchMode(searchParams)
+  const hasSearch = searchMode !== "none"
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: [
+          "unified-practitioners",
+          searchParams.providerName,
+          searchParams.npi,
+          searchParams.location,
+          pagination.page || 1,
+          pagination.sort,
+        ],
+        queryFn:
+          searchMode === "providers" || searchMode === "both"
+            ? () => adapter.searchProviders(searchParams, pagination)
+            : skipToken,
+        placeholderData: keepPreviousData,
+      },
+      {
+        queryKey: [
+          "unified-organizations",
+          searchParams.organizationName,
+          searchParams.npi,
+          searchParams.location,
+          pagination.page || 1,
+          pagination.sort,
+        ],
+        queryFn:
+          searchMode === "organizations" || searchMode === "both"
+            ? () => adapter.searchOrganizations(searchParams, pagination)
+            : skipToken,
+        placeholderData: keepPreviousData,
+      },
+      {
+        queryKey: [
+          "unified-cross-entity",
+          searchParams.providerName,
+          searchParams.organizationName,
+          searchParams.npi,
+          searchParams.location,
+          pagination.page || 1,
+          pagination.sort,
+        ],
+        queryFn:
+          searchMode === "cross-entity"
+            ? () => adapter.searchCrossEntity(searchParams, pagination)
+            : skipToken,
+        placeholderData: keepPreviousData,
+      },
+    ],
+  })
+
+  const [practitionerQuery, organizationQuery, crossEntityQuery] = results
+
+  return {
+    practitioners: practitionerQuery.data as
+      | FHIRCollection<FHIRPractitioner>
+      | undefined,
+    organizations: organizationQuery.data as
+      | FHIRCollection<FHIROrganization>
+      | undefined,
+    practitionerRoles: crossEntityQuery.data as
+      | FHIRCollection<FHIRPractitionerRole>
+      | undefined,
+    searchMode,
+    isLoading:
+      practitionerQuery.isLoading ||
+      organizationQuery.isLoading ||
+      crossEntityQuery.isLoading,
+    isPlaceholderData:
+      (practitionerQuery.isPlaceholderData ?? false) ||
+      (organizationQuery.isPlaceholderData ?? false) ||
+      (crossEntityQuery.isPlaceholderData ?? false),
+    error:
+      practitionerQuery.error ||
+      organizationQuery.error ||
+      crossEntityQuery.error,
+    hasSearch,
+  }
+}

--- a/playwright/tests/local/organizations/organizations.spec.ts
+++ b/playwright/tests/local/organizations/organizations.spec.ts
@@ -189,8 +189,8 @@ test.describe("Organization show", () => {
     const tableRows = practitionerTable.locator('tbody tr');
     await expect(tableRows).toHaveCount(1);
     await expect(tableRows).toContainText("Jane Doe")
-    const practitionerLink = await page.getByRole("link", {name: "Jane Doe"})
-    expect(practitionerLink).toHaveAttribute("href", "/practitioners/6846963d-7814-4c70-ae3d-8a8419a7c9c6")
+    const practitionerLink = page.getByRole("link", {name: "Jane Doe"})
+    await expect(practitionerLink).toHaveAttribute("href", "/practitioners/6846963d-7814-4c70-ae3d-8a8419a7c9c6")
   })
   test("View an organization with multiple practitioner relationships", async ({page}) => {
     await page.goto(`/organizations/0c1f8f84-0502-4444-b636-8fee4ab76e32`)

--- a/playwright/tests/local/user-journeys/landing-navigation.spec.ts
+++ b/playwright/tests/local/user-journeys/landing-navigation.spec.ts
@@ -12,33 +12,27 @@ test.describe("Landing Page → Search Page Navigation", () => {
     await expect(page).toHaveURL("/search")
   })
 
-  test("search hub displays both resource type options", async ({ page }) => {
+  test("unified search form is displayed at /search", async ({ page }) => {
     await page.goto("/search")
     await expect(page).toHaveURL("/search")
 
-    const practitionerButton = page.getByRole("link", { name: /practitioner/i })
-    const organizationButton = page.getByRole("link", { name: /organization/i })
-
-    await expect(practitionerButton).toBeVisible()
-    await expect(organizationButton).toBeVisible()
-
-    await expect(practitionerButton).toHaveAttribute("href", "/practitioners/search")
-    await expect(organizationButton).toHaveAttribute("href", "/organizations/search")
+    await expect(page.getByRole("heading", { name: "Search Providers" })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /provider name/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /npi number/i })).toBeVisible()
   })
 
-  test("search hub practitioner button navigates correctly", async ({ page }) => {
+  test("search button is disabled with no input at /search", async ({ page }) => {
     await page.goto("/search")
 
-    await page.getByRole("link", { name: /practitioner/i }).click()
-    await expect(page).toHaveURL("/practitioners/search")
-    await expect(page.getByText("Search Practitioners")).toBeVisible()
+    await expect(page.getByRole("button", { name: /search providers/i })).toBeDisabled()
   })
 
-  test("search hub organization button navigates correctly", async ({ page }) => {
+  test("navigating to /search shows unified search form with all inputs", async ({ page }) => {
     await page.goto("/search")
 
-    await page.getByRole("link", { name: /organization/i }).click()
-    await expect(page).toHaveURL("/organizations/search")
-    await expect(page.getByText("Organization search")).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /provider name/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /organization/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /npi number/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /location/i })).toBeVisible()
   })
 })

--- a/playwright/tests/local/user-journeys/organization-journey.spec.ts
+++ b/playwright/tests/local/user-journeys/organization-journey.spec.ts
@@ -115,48 +115,48 @@ test.describe("Organization Journey", () => {
     await expect(page.getByTestId("organization-name")).toContainText(/TEST/)
   })
 
-  // test("search -> detail -> report feedback", async ({ page }) => {
-  //   await page.goto("/organizations/search")
+  test("search -> detail -> report feedback", async ({ page }) => {
+    await page.goto("/search")
 
-  //   await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567893")
-  //   await page.getByRole("button", { name: "Search" }).click()
+    await page.getByRole("textbox", { name: /npi number/i }).fill("1234567893")
+    await page.getByRole("button", { name: /search providers/i }).click()
 
-  //   await page.getByRole("link", { name: "AAA Test Org" }).click()
-  //   await expect(page).toHaveURL(`/organizations/${organization.id}`)
+    await page.getByRole("link", { name: "AAA Test Org" }).click()
+    await expect(page).toHaveURL(`/organizations/${organization.id}`)
 
-  //   // open feedback dialog
-  //   await page.getByRole("button", { name: "Report an issue" }).click()
+    // open feedback dialog
+    await page.getByRole("button", { name: "Report an issue" }).click()
 
-  //   const dialog = page.getByRole("dialog")
-  //   await expect(dialog).toBeVisible()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
 
-  //   // confirm organization name is shown in the form
-  //   await expect(dialog.getByText(organization.name)).toBeVisible()
+    // confirm organization name is shown in the form
+    await expect(dialog.getByText(organization.name)).toBeVisible()
   
-  //   // check issue type
-  //   await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
-  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+    // check issue type
+    await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
+    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
 
-  //   const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
-  //   await captcha.click()
-  //   await expect(
-  //     dialog.getByRole("checkbox", { name: /Verified/i })
-  //   ).toBeChecked({ timeout: 10000 })
+    const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
+    await captcha.click()
+    await expect(
+      dialog.getByRole("checkbox", { name: /Verified/i })
+    ).toBeChecked({ timeout: 10000 })
 
-  //   // fill details after captcha is verified
-  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+    // fill details after captcha is verified
+    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
   
-  //   await dialog.getByRole("button", { name: "Submit" }).click()
+    await dialog.getByRole("button", { name: "Submit" }).click()
 
-  //   // confirm success message
-  //   await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
+    // confirm success message
+    await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
 
-  //   // close the dialog
-  //   await dialog.getByRole("button", { name: "Close", exact: true }).click()
-  //   await expect(dialog).not.toBeVisible()
+    // close the dialog
+    await dialog.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(dialog).not.toBeVisible()
 
-  //   // confirm we're still on the detail page
-  //   await expect(page).toHaveURL(`/organizations/${organization.id}`)
-  //   await expect(page.getByTestId("organization-name")).toContainText(organization.name)
-  // })
+    // confirm we're still on the detail page
+    await expect(page).toHaveURL(`/organizations/${organization.id}`)
+    await expect(page.getByTestId("organization-name")).toContainText(organization.name)
+  })
 })

--- a/playwright/tests/local/user-journeys/organization-journey.spec.ts
+++ b/playwright/tests/local/user-journeys/organization-journey.spec.ts
@@ -28,16 +28,7 @@ test.beforeAll(async ({ request }) => {
 
 test.describe("Organization Journey", () => {
   test("landing -> search hub -> organization search -> detail view", async ({ page }) => {
-    // start at landing page
-    await page.goto("/")
-    await expect(page).toHaveURL("/")
-
-    // then, navigate to search hub
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await expect(page).toHaveURL("/search")
-
-    // then, select Organization search
-    await page.getByRole("link", { name: /organization/i }).click()
+    await page.goto("/organizations/search")
     await expect(page).toHaveURL("/organizations/search")
     await expect(page.getByText("Organization search")).toBeVisible()
 
@@ -59,11 +50,8 @@ test.describe("Organization Journey", () => {
   })
 
   test("landing -> last page -> organization detail", async ({ page }) => {
-    await page.goto("/")
-  
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /organization/i }).click()
-  
+    await page.goto("/organizations/search")
+
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("TEST")
     await page.getByRole("button", { name: "Search" }).click()
 
@@ -92,10 +80,7 @@ test.describe("Organization Journey", () => {
   })
 
   test("organization journey with partial name search", async ({ page }) => {
-    await page.goto("/")
-
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /organization/i }).click()
+    await page.goto("/organizations/search")
 
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("AAA")
     await page.getByRole("button", { name: "Search" }).click()
@@ -107,10 +92,7 @@ test.describe("Organization Journey", () => {
   })
 
   test("organization journey with sorting functionality", async ({ page }) => {
-    await page.goto("/")
-
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /organization/i }).click()
+    await page.goto("/organizations/search")
 
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("Test")
     await page.getByRole("button", { name: "Search" }).click()
@@ -133,48 +115,48 @@ test.describe("Organization Journey", () => {
     await expect(page.getByTestId("organization-name")).toContainText(/TEST/)
   })
 
-  test("search -> detail -> report feedback", async ({ page }) => {
-    await page.goto("/organizations/search")
+  // test("search -> detail -> report feedback", async ({ page }) => {
+  //   await page.goto("/organizations/search")
 
-    await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567893")
-    await page.getByRole("button", { name: "Search" }).click()
+  //   await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567893")
+  //   await page.getByRole("button", { name: "Search" }).click()
 
-    await page.getByRole("link", { name: "AAA Test Org" }).click()
-    await expect(page).toHaveURL(`/organizations/${organization.id}`)
+  //   await page.getByRole("link", { name: "AAA Test Org" }).click()
+  //   await expect(page).toHaveURL(`/organizations/${organization.id}`)
 
-    // open feedback dialog
-    await page.getByRole("button", { name: "Report an issue" }).click()
+  //   // open feedback dialog
+  //   await page.getByRole("button", { name: "Report an issue" }).click()
 
-    const dialog = page.getByRole("dialog")
-    await expect(dialog).toBeVisible()
+  //   const dialog = page.getByRole("dialog")
+  //   await expect(dialog).toBeVisible()
 
-    // confirm organization name is shown in the form
-    await expect(dialog.getByText(organization.name)).toBeVisible()
+  //   // confirm organization name is shown in the form
+  //   await expect(dialog.getByText(organization.name)).toBeVisible()
   
-    // check issue type
-    await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
-    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+  //   // check issue type
+  //   await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
+  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
 
-    const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
-    await captcha.click()
-    await expect(
-      dialog.getByRole("checkbox", { name: /Verified/i })
-    ).toBeChecked({ timeout: 10000 })
+  //   const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
+  //   await captcha.click()
+  //   await expect(
+  //     dialog.getByRole("checkbox", { name: /Verified/i })
+  //   ).toBeChecked({ timeout: 10000 })
 
-    // fill details after captcha is verified
-    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+  //   // fill details after captcha is verified
+  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
   
-    await dialog.getByRole("button", { name: "Submit" }).click()
+  //   await dialog.getByRole("button", { name: "Submit" }).click()
 
-    // confirm success message
-    await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
+  //   // confirm success message
+  //   await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
 
-    // close the dialog
-    await dialog.getByRole("button", { name: "Close", exact: true }).click()
-    await expect(dialog).not.toBeVisible()
+  //   // close the dialog
+  //   await dialog.getByRole("button", { name: "Close", exact: true }).click()
+  //   await expect(dialog).not.toBeVisible()
 
-    // confirm we're still on the detail page
-    await expect(page).toHaveURL(`/organizations/${organization.id}`)
-    await expect(page.getByTestId("organization-name")).toContainText(organization.name)
-  })
+  //   // confirm we're still on the detail page
+  //   await expect(page).toHaveURL(`/organizations/${organization.id}`)
+  //   await expect(page.getByTestId("organization-name")).toContainText(organization.name)
+  // })
 })

--- a/playwright/tests/local/user-journeys/practitioner-journey.spec.ts
+++ b/playwright/tests/local/user-journeys/practitioner-journey.spec.ts
@@ -117,48 +117,48 @@ test.describe("Practitioner Journey", () => {
     await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
   })
 
-  // test("search -> detail -> report feedback", async ({ page }) => {
-  //   await page.goto("/practitioners/search")
+  test("search -> detail -> report feedback", async ({ page }) => {
+    await page.goto("/search")
 
-  //   await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567894")
-  //   await page.getByRole("button", { name: "Search" }).click()
+    await page.getByRole("textbox", { name: /npi number/i }).fill("1234567894")
+    await page.getByRole("button", { name: /search providers/i }).click()
 
-  //   await page.getByRole("link", { name: /AAA Test Practitioner/i }).click()
-  //   await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
+    await page.getByRole("link", { name: /AAA Test Practitioner/i }).click()
+    await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
 
-  //   // open feedback dialog
-  //   await page.getByRole("button", { name: "Report an issue" }).click()
+    // open feedback dialog
+    await page.getByRole("button", { name: "Report an issue" }).click()
 
-  //   const dialog = page.getByRole("dialog")
-  //   await expect(dialog).toBeVisible()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
 
-  //   // confirm practitioner name is shown in the form
-  //   await expect(dialog.getByText(practitioner.name)).toBeVisible()
-  
-  //   // check issue type
-  //   await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
-  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+    // confirm practitioner name is shown in the form
+    await expect(dialog.getByText(practitioner.name)).toBeVisible()
 
-  //   const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
-  //   await captcha.click()
-  //   await expect(
-  //     dialog.getByRole("checkbox", { name: /Verified/i })
-  //   ).toBeChecked({ timeout: 10000 })
+    // check issue type
+    await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
+    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
 
-  //   // fill details after captcha is verified
-  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
-  
-  //   await dialog.getByRole("button", { name: "Submit" }).click()
+    const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
+    await captcha.click()
+    await expect(
+      dialog.getByRole("checkbox", { name: /Verified/i })
+    ).toBeChecked({ timeout: 10000 })
 
-  //   // confirm success message
-  //   await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
+    // fill details after captcha is verified
+    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
 
-  //   // close the dialog
-  //   await dialog.getByRole("button", { name: "Close", exact: true }).click()
-  //   await expect(dialog).not.toBeVisible()
+    await dialog.getByRole("button", { name: "Submit" }).click()
 
-  //   // confirm we're still on the detail page
-  //   await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
-  //   await expect(page.getByTestId("practitioner-name")).toContainText(practitioner.name)
-  // })
+    // confirm success message
+    await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
+
+    // close the dialog
+    await dialog.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(dialog).not.toBeVisible()
+
+    // confirm we're still on the detail page
+    await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
+    await expect(page.getByTestId("practitioner-name")).toContainText(practitioner.name)
+  })
 })

--- a/playwright/tests/local/user-journeys/practitioner-journey.spec.ts
+++ b/playwright/tests/local/user-journeys/practitioner-journey.spec.ts
@@ -36,16 +36,7 @@ test.beforeAll(async ({ request }) => {
 
 test.describe("Practitioner Journey", () => {
   test("landing -> search hub -> practitioner search -> detail view", async ({ page }) => {
-    // first, start at landing page
-    await page.goto("/")
-    await expect(page).toHaveURL("/")
-
-    // then, navigate to search hub
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await expect(page).toHaveURL("/search")
-
-    // then, select Practitioner search
-    await page.getByRole("link", { name: /practitioner/i }).click()
+    await page.goto("/practitioners/search")
     await expect(page).toHaveURL("/practitioners/search")
     await expect(page.getByText("Search Practitioners")).toBeVisible()
 
@@ -66,11 +57,8 @@ test.describe("Practitioner Journey", () => {
   })
 
   test("landing -> last page -> practitioner detail", async ({ page }) => {
-    await page.goto("/")
-  
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /practitioner/i }).click()
-  
+    await page.goto("/practitioners/search")
+
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("TEST")
     await page.getByRole("button", { name: "Search" }).click()
   
@@ -95,10 +83,7 @@ test.describe("Practitioner Journey", () => {
   })
 
   test("practitioner journey with partial name search", async ({ page }) => {
-    await page.goto("/")
-
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /practitioner/i }).click()
+    await page.goto("/practitioners/search")
 
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("AAA")
     await page.getByRole("button", { name: "Search" }).click()
@@ -110,10 +95,7 @@ test.describe("Practitioner Journey", () => {
   })
 
   test("practitioner journey with sorting functionality", async ({ page }) => {
-    await page.goto("/")
-
-    await page.getByRole("link", { name: /search/i }).first().click()
-    await page.getByRole("link", { name: /practitioner/i }).click()
+    await page.goto("/practitioners/search")
 
     await page.getByRole("textbox", { name: "Name or NPI" }).fill("AAA")
     await page.getByRole("button", { name: "Search" }).click()
@@ -135,48 +117,48 @@ test.describe("Practitioner Journey", () => {
     await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
   })
 
-  test("search -> detail -> report feedback", async ({ page }) => {
-    await page.goto("/practitioners/search")
+  // test("search -> detail -> report feedback", async ({ page }) => {
+  //   await page.goto("/practitioners/search")
 
-    await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567894")
-    await page.getByRole("button", { name: "Search" }).click()
+  //   await page.getByRole("textbox", { name: "Name or NPI" }).fill("1234567894")
+  //   await page.getByRole("button", { name: "Search" }).click()
 
-    await page.getByRole("link", { name: /AAA Test Practitioner/i }).click()
-    await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
+  //   await page.getByRole("link", { name: /AAA Test Practitioner/i }).click()
+  //   await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
 
-    // open feedback dialog
-    await page.getByRole("button", { name: "Report an issue" }).click()
+  //   // open feedback dialog
+  //   await page.getByRole("button", { name: "Report an issue" }).click()
 
-    const dialog = page.getByRole("dialog")
-    await expect(dialog).toBeVisible()
+  //   const dialog = page.getByRole("dialog")
+  //   await expect(dialog).toBeVisible()
 
-    // confirm practitioner name is shown in the form
-    await expect(dialog.getByText(practitioner.name)).toBeVisible()
+  //   // confirm practitioner name is shown in the form
+  //   await expect(dialog.getByText(practitioner.name)).toBeVisible()
   
-    // check issue type
-    await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
-    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+  //   // check issue type
+  //   await dialog.getByRole("checkbox", { name: /Practice location/i }).check()
+  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
 
-    const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
-    await captcha.click()
-    await expect(
-      dialog.getByRole("checkbox", { name: /Verified/i })
-    ).toBeChecked({ timeout: 10000 })
+  //   const captcha = dialog.getByRole("checkbox", { name: /I'm not a robot/i })
+  //   await captcha.click()
+  //   await expect(
+  //     dialog.getByRole("checkbox", { name: /Verified/i })
+  //   ).toBeChecked({ timeout: 10000 })
 
-    // fill details after captcha is verified
-    await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
+  //   // fill details after captcha is verified
+  //   await dialog.getByRole("textbox", { name: /details/i }).fill("Address is outdated")
   
-    await dialog.getByRole("button", { name: "Submit" }).click()
+  //   await dialog.getByRole("button", { name: "Submit" }).click()
 
-    // confirm success message
-    await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
+  //   // confirm success message
+  //   await expect(dialog.getByText(/Submission sent/i)).toBeVisible()
 
-    // close the dialog
-    await dialog.getByRole("button", { name: "Close", exact: true }).click()
-    await expect(dialog).not.toBeVisible()
+  //   // close the dialog
+  //   await dialog.getByRole("button", { name: "Close", exact: true }).click()
+  //   await expect(dialog).not.toBeVisible()
 
-    // confirm we're still on the detail page
-    await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
-    await expect(page.getByTestId("practitioner-name")).toContainText(practitioner.name)
-  })
+  //   // confirm we're still on the detail page
+  //   await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
+  //   await expect(page.getByTestId("practitioner-name")).toContainText(practitioner.name)
+  // })
 })

--- a/playwright/tests/local/user-journeys/unified-search-journey.spec.ts
+++ b/playwright/tests/local/user-journeys/unified-search-journey.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "@playwright/test"
+import { PRACTITIONER, ORGANIZATION } from "../constants"
+
+let practitioner = PRACTITIONER
+let organization = ORGANIZATION
+
+test.beforeAll(async ({ request }) => {
+  const [practResp, orgResp] = await Promise.all([
+    request.get("/fhir/Practitioner/?identifier=NPI|1234567894"),
+    request.get("/fhir/Organization/?identifier=1234567893"),
+  ])
+
+  const practPayload = await practResp.json()
+  const practResource = practPayload.results.entry[0].resource
+  const nameRecord = practResource.name?.[0]
+  practitioner = {
+    id: practResource.id,
+    name:
+      nameRecord?.text ||
+      `${nameRecord?.given?.[0] || ""} ${nameRecord?.family || ""}`.trim(),
+    npi:
+      practResource.identifier?.find(
+        (i: { system?: string }) =>
+          i.system === "http://hl7.org/fhir/sid/us-npi" ||
+          i.system === "http://terminology.hl7.org/NamingSystem/npi",
+      )?.value || practResource.identifier?.[0]?.value,
+  }
+
+  const orgPayload = await orgResp.json()
+  const orgResource = orgPayload.results.entry[0].resource
+  organization = {
+    id: orgResource.id,
+    name: orgResource.name,
+    npi: orgResource.identifier[0].value,
+  }
+
+  expect(practitioner).toMatchObject(
+    expect.objectContaining({
+      id: expect.stringMatching(/[\d-]+/),
+      name: expect.stringContaining("AAA Test Practitioner"),
+      npi: "1234567894",
+    }),
+  )
+  expect(organization).toMatchObject(
+    expect.objectContaining({
+      id: expect.stringMatching(/[\d-]+/),
+      name: "AAA Test Org",
+      npi: "1234567893",
+    }),
+  )
+})
+
+test.describe("Unified Search Journey", () => {
+  test("initial state: form visible, search button disabled", async ({ page }) => {
+    await page.goto("/search")
+    await expect(page).toHaveURL("/search")
+
+    await expect(page.getByRole("textbox", { name: /provider name/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /organization/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /npi number/i })).toBeVisible()
+    await expect(page.getByRole("textbox", { name: /location/i })).toBeVisible()
+    await expect(page.getByRole("button", { name: /search providers/i })).toBeDisabled()
+  })
+
+  test("search by provider name returns results", async ({ page }) => {
+    await page.goto("/search")
+
+    await page.getByRole("textbox", { name: /provider name/i }).fill("AAA Test Practitioner")
+    await page.getByRole("button", { name: /search providers/i }).click()
+
+    await expect(page.getByTestId("searchresults")).toBeVisible()
+    await expect(page.getByRole("link", { name: /AAA Test Practitioner/i })).toBeVisible()
+  })
+
+  test("search by NPI navigates to practitioner detail", async ({ page }) => {
+    await page.goto("/search")
+
+    await page.getByRole("textbox", { name: /npi number/i }).fill("1234567894")
+    await page.getByRole("button", { name: /search providers/i }).click()
+
+    await expect(page.getByTestId("searchresults")).toBeVisible()
+    await expect(page.getByRole("link", { name: /AAA Test Practitioner/i })).toBeVisible()
+
+    await page.getByRole("link", { name: /AAA Test Practitioner/i }).click()
+    await expect(page).toHaveURL(`/practitioners/${practitioner.id}`)
+  })
+
+  test("search by organization name returns results", async ({ page }) => {
+    await page.goto("/search")
+
+    await page.getByRole("textbox", { name: /organization/i }).fill("AAA Test Org")
+    await page.getByRole("button", { name: /search providers/i }).click()
+
+    await expect(page.getByTestId("searchresults")).toBeVisible()
+    await expect(page.getByRole("link", { name: /AAA Test Org/i })).toBeVisible()
+  })
+
+  test("location-only input shows hint and keeps button disabled", async ({ page }) => {
+    await page.goto("/search")
+
+    await page.getByRole("textbox", { name: /location/i }).fill("CA")
+    await expect(page.getByRole("button", { name: /search providers/i })).toBeDisabled()
+    await expect(page.getByText(/please also enter a provider name/i)).toBeVisible()
+  })
+
+  test("clear button resets the form", async ({ page }) => {
+    await page.goto("/search")
+
+    await page.getByRole("textbox", { name: /provider name/i }).fill("AAA Test Practitioner")
+    await expect(page.getByRole("button", { name: /search providers/i })).not.toBeDisabled()
+
+    await page.getByRole("button", { name: /clear/i }).click()
+    await expect(page.getByRole("textbox", { name: /provider name/i })).toHaveValue("")
+    await expect(page.getByRole("button", { name: /search providers/i })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Unified Search Experience

### Jira Ticket [#742](https://jiraent.cms.gov/browse/NDH-742)

## Problem

The existing search experience required users to know in advance whether they were looking for a
practitioner or an organization, routing them through two separate search pages
(/practitioners/search and /organizations/search). There was no way to search across both resource
types at once, or to find a practitioner by the organization they work at.

## Solution

Added a unified search experience at /search that replaces the old search hub landing page. The new
page provides a single form with four fields — provider name, organization name, NPI, and location —
and intelligently routes the query based on what's filled in:

- Provider name only → searches practitioners
- Organization name only → searches organizations
- NPI only → looks up either resource type by NPI
- Provider name + organization name → cross-entity search via PractitionerRole, showing practitioners filtered by their affiliated organization
- Location → refines any of the above; location alone is not a valid search and shows a hint

## Result

Users can now search for both practitioners and organizations from a single entry point at /search.
Cross-entity searches (provider at organization) are supported without requiring two separate
queries. The search button is disabled unless at least one of provider name, organization name, or
NPI is filled, preventing empty searches.

## Test Plan
- run `make up`
- go through search experience

