### PR TITLE
Add HTE spec links

### DIFF
--- a/frontend/src/pages/Developers/Developers.content.md
+++ b/frontend/src/pages/Developers/Developers.content.md
@@ -72,6 +72,11 @@ The initial beta release of the National Provider Directory API makes the follow
 | /fhir/Practitioner/<id>     | lists individuals that provide healthcare services (I.e. individuals having a type 1 National Provider Identifier), as well as details about those practitioners; supplying an id allows developers to retrieve a single practitioner record                                                                                                                                        |
 | /fhir/PractitionerRole/<id> | lists relationships between individuals that provide healthcare services, the organizations within which they provide healthcare services, the locations at which they practice, and the interoperability endpoints that pertain to those relationships; supplying an id allows developers to retrieve a single practitioner role record                                            |
 
+## Health Tech Ecosystem
+
+- [Health Tech Ecosystem Data Release Specifications](https://github.com/ftrotter-gov/HTE_data_release_specifications)
+- [CMS Health Tech Ecosystem Interoperability Framework](https://www.cms.gov/health-technology-ecosystem/interoperability-framework)
+
 # Developer sandbox
 
 To explore the data in an interactive developer sandbox integrated with detailed documentation, please visit the National Provider Directory [Swagger documentation](/fhir/docs/).


### PR DESCRIPTION
<img width="667" height="280" alt="image" src="https://github.com/user-attachments/assets/cbb3f16a-bba3-49ab-9970-871bf6663252" />

Adds the following links to the developer resources page.

- [Health Tech Ecosystem Data Release Specifications](https://github.com/ftrotter-gov/HTE_data_release_specifications)
- [CMS Health Tech Ecosystem Interoperability Framework](https://www.cms.gov/health-technology-ecosystem/interoperability-framework)

## module-name: Add health tech ecosystem links to developer resources page

### Jira Ticket # NDH-1060

## Problem

Stakeholders want these HTE links to appear on the developers page

## Solution

Added the links

## Result

HTE Links appear on the developers page

## Test Plan

Run the application locally, note that links have been added under the list of open endpoints.
