### PR TITLE
Add HTE links and direction to email if there are problems

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,9 @@
-Django==5.2.12
+Django==5.2.13
 Faker==38.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 PyYAML==6.0.2
-Pygments==2.19.2
+Pygments==2.20.0
 SQLAlchemy==2.0.41
 WTForms==3.1.2
 altcha==1.0.0

--- a/frontend/src/pages/Developers/Developers.content.md
+++ b/frontend/src/pages/Developers/Developers.content.md
@@ -72,6 +72,13 @@ The initial beta release of the National Provider Directory API makes the follow
 | /fhir/Practitioner/<id>     | lists individuals that provide healthcare services (I.e. individuals having a type 1 National Provider Identifier), as well as details about those practitioners; supplying an id allows developers to retrieve a single practitioner record                                                                                                                                        |
 | /fhir/PractitionerRole/<id> | lists relationships between individuals that provide healthcare services, the organizations within which they provide healthcare services, the locations at which they practice, and the interoperability endpoints that pertain to those relationships; supplying an id allows developers to retrieve a single practitioner role record                                            |
 
+## Health Tech Ecosystem
+
+- [Health Tech Ecosystem Data Release Specifications](https://github.com/ftrotter-gov/HTE_data_release_specifications)
+- [CMS Health Tech Ecosystem Interoperability Framework](https://www.cms.gov/health-technology-ecosystem/interoperability-framework)
+
+To report issues with these files please send an email to [npd@cms.hhs.gov](npd@cms.hhs.gov)
+
 # Developer sandbox
 
 To explore the data in an interactive developer sandbox integrated with detailed documentation, please visit the National Provider Directory [Swagger documentation](/fhir/docs/).


### PR DESCRIPTION
<img width="830" height="270" alt="image" src="https://github.com/user-attachments/assets/fb294fdc-47b8-4431-9223-f0d2a7b58ce3" />

Adds the following links to the developer resources page.

- [Health Tech Ecosystem Data Release Specifications](https://github.com/ftrotter-gov/HTE_data_release_specifications)
- [CMS Health Tech Ecosystem Interoperability Framework](https://www.cms.gov/health-technology-ecosystem/interoperability-framework)

along with directions to email us if there are problems / questions

## module-name: Add health tech ecosystem links to developer resources page

### Jira Ticket # NDH-1060

## Problem

Stakeholders want these HTE links to appear on the developers page

## Solution

Added the links

## Result

HTE Links appear on the developers page

## Test Plan

Run the application locally, note that links have been added under the list of open endpoints.
