### PR TITLE
Update silo static site to read manifest json

### DIFF
--- a/silo_site/Dockerfile
+++ b/silo_site/Dockerfile
@@ -10,4 +10,6 @@ COPY app.py .
 ADD static ./static
 # Run the app on 8080
 EXPOSE 8080/tcp
+ENV PYTHONUNBUFFERED=1
+
 CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "2", "app:app"]

--- a/silo_site/app.py
+++ b/silo_site/app.py
@@ -18,7 +18,6 @@ from botocore.exceptions import ClientError
 from flask import Flask, Response, abort, jsonify, redirect, send_file
 import zstandard
 
-
 ROOT_DIR = Path(__file__).resolve().parent.parent
 SITE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = SITE_DIR / "static"
@@ -67,6 +66,16 @@ def _resource_filename(resource_name: str) -> str:
 
 def _get_resource_from_filename(filename: str) -> str:
     return filename.split("_")[0]
+
+def _append_zst(filename: str) -> str:
+    return filename + ".zst"
+
+def _sort_keys_by_resource_order(keys: list[str]) -> list[str]:
+    output = [0 for i in range(len(RESOURCE_ORDER))]
+    for key in keys:
+        index = RESOURCE_ORDER.index(_get_resource_from_filename(key))
+        output[index] = key
+    return output
 
 def _sample_fields(record: dict[str, Any]) -> dict[str, Any]:
     ordered_keys = [
@@ -145,12 +154,13 @@ class ReleaseStoreBase:
         files_meta = manifest.get("files", {})
         records: list[FileRecord] = []
 
-        for filename in files_meta.keys():
-            manifest_key = filename.removesuffix(".zst")
-            meta = files_meta.get(manifest_key, {})
+        for filename in _sort_keys_by_resource_order(files_meta.keys()):
+            meta = files_meta.get(filename, {})
+            resource_name = _get_resource_from_filename(filename)
+            filename = _append_zst(filename)
             records.append(
                 FileRecord(
-                    resource_name=_get_resource_from_filename(filename),
+                    resource_name=resource_name,
                     filename=filename,
                     download_path=f"/downloads/{filename}",
                     compressed_bytes=self.compressed_bytes(filename),

--- a/silo_site/app.py
+++ b/silo_site/app.py
@@ -71,7 +71,6 @@ def _get_resource_from_filename(filename: str) -> str:
 def _append_zst(filename: str) -> str:
     return filename + ".zst"
 
-
 def _sort_keys_by_resource_order(keys: Iterable[str]) -> list[str]:
     return sorted(
         keys,

--- a/silo_site/app.py
+++ b/silo_site/app.py
@@ -153,7 +153,6 @@ class ReleaseStoreBase:
         manifest = self.manifest()
         files_meta = manifest.get("files", {})
         records: list[FileRecord] = []
-
         for filename in _sort_keys_by_resource_order(files_meta.keys()):
             meta = files_meta.get(filename, {})
             resource_name = _get_resource_from_filename(filename)

--- a/silo_site/app.py
+++ b/silo_site/app.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import io
@@ -70,12 +71,12 @@ def _get_resource_from_filename(filename: str) -> str:
 def _append_zst(filename: str) -> str:
     return filename + ".zst"
 
-def _sort_keys_by_resource_order(keys: list[str]) -> list[str]:
-    output = [0 for i in range(len(RESOURCE_ORDER))]
-    for key in keys:
-        index = RESOURCE_ORDER.index(_get_resource_from_filename(key))
-        output[index] = key
-    return output
+
+def _sort_keys_by_resource_order(keys: Iterable[str]) -> list[str]:
+    return sorted(
+        keys,
+        key=lambda key: RESOURCE_ORDER.index(_get_resource_from_filename(key)),
+    )
 
 def _sample_fields(record: dict[str, Any]) -> dict[str, Any]:
     ordered_keys = [

--- a/silo_site/app.py
+++ b/silo_site/app.py
@@ -65,6 +65,8 @@ def _guess_release_date() -> str | None:
 def _resource_filename(resource_name: str) -> str:
     return f"{resource_name}.ndjson.zst"
 
+def _get_resource_from_filename(filename: str) -> str:
+    return filename.split("_")[0]
 
 def _sample_fields(record: dict[str, Any]) -> dict[str, Any]:
     ordered_keys = [
@@ -142,13 +144,13 @@ class ReleaseStoreBase:
         manifest = self.manifest()
         files_meta = manifest.get("files", {})
         records: list[FileRecord] = []
-        for resource_name in RESOURCE_ORDER:
-            filename = _resource_filename(resource_name)
+
+        for filename in files_meta.keys():
             manifest_key = filename.removesuffix(".zst")
             meta = files_meta.get(manifest_key, {})
             records.append(
                 FileRecord(
-                    resource_name=resource_name,
+                    resource_name=_get_resource_from_filename(filename),
                     filename=filename,
                     download_path=f"/downloads/{filename}",
                     compressed_bytes=self.compressed_bytes(filename),

--- a/silo_site/compose.yml
+++ b/silo_site/compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
     volumes:
       - ./static:/app/static
+      - ./app.py:/app/app.py
     ports:
     - "8080:8080"
     environment:

--- a/silo_site/compose.yml
+++ b/silo_site/compose.yml
@@ -1,0 +1,17 @@
+name: bulk-download-site
+
+services:
+  app:
+    build:
+      context: .
+    volumes:
+      - ./static:/app/static
+    ports:
+    - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_REGION=us-east-1
+      - SILO_S3_BUCKET=npd-east-prod-bulk-site

--- a/silo_site/requirements.txt
+++ b/silo_site/requirements.txt
@@ -1,0 +1,5 @@
+Flask>=3.0,<4
+boto3>=1.34,<2
+botocore>=1.34,<2
+zstandard>=0.22,<1
+gunicorn>=25.3,<27

--- a/silo_site/static/styles.css
+++ b/silo_site/static/styles.css
@@ -233,7 +233,7 @@ button:focus-visible {
 
 .file-name,
 .file-label {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   word-break: normal;
 }
 


### PR DESCRIPTION
<img width="1303" height="943" alt="image" src="https://github.com/user-attachments/assets/e503529e-1d6e-48c2-8d47-d875902d27e0" />

<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).

-->

## module-name: Update silo static site to read manifest.json

### Jira Ticket #

## Problem

The static site expects Palantir data exports files to be renamed before they can be published by the website

## Solution

Update the backend processes in app.py to read the manifest.json to fetch accurate file names rather than expecting the names to be consistent between releases.

## Result

- It should be easier to push updates to the static site when a data release is created
- Original size, compressed size, compression ratio values populate as expected

## Test Plan

```
kion f # assume prod role
docker compose up --build
```

1. Open `localhost:8080`
2. Click download buttons of various resources
3. Click load sample buttons of various resources
