### PR TITLE
Update HTE link in header

### DIFF
--- a/silo_site/static/index.html
+++ b/silo_site/static/index.html
@@ -41,7 +41,7 @@
             <p>Information about how ecosystem partners work together.</p>
           </div>
           <ul>
-              <li><a href="https://github.com/ftrotter-gov/HTE_data_release_specifications">Health Tech Ecosystem Data Release Specifications</a></li>
+              <li><a href="https://github.com/CMS-Enterprise/HTE_data_release_specifications">Health Tech Ecosystem Data Release Specifications</a></li>
               <li><a href="https://www.cms.gov/health-technology-ecosystem/interoperability-framework">CMS Health Tech Ecosystem Interoperability Framework</a></li>
           </ul>
           <p>To report issues with these files please send an email to <a href="mailto:npd@cms.hhs.gov">npd@cms.hhs.gov</a></p>


### PR DESCRIPTION
## module-name: Update HTE spec repo link

### Jira Ticket #

## Problem

We want to point folks to a CMS owned repo containing the HTE specifications.

## Solution

Update the link to [CMS-Enterprise/HTE_data_release_specifications](https://github.com/CMS-Enterprise/HTE_data_release_specifications) from Fred's repo.

## Result



## Test Plan

1. view ecosystem links
2. validate that link goes to https://github.com/CMS-Enterprise/HTE_data_release_specifications